### PR TITLE
feat(auth): configure method security handler

### DIFF
--- a/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
+++ b/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
-@EnableMethodSecurity   // 关键：启用 @PreAuthorize 等方法安全拦截
 @SpringBootApplication(scanBasePackages = "com.xrcgs")
 @ConfigurationPropertiesScan(basePackages = "com.xrcgs") // 关键：让 @ConfigurationProperties 生效
 @MapperScan(

--- a/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/IamMethodSecurityExpressionHandler.java
+++ b/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/IamMethodSecurityExpressionHandler.java
@@ -1,7 +1,6 @@
 package com.xrcgs.auth.security;
 
 import com.xrcgs.common.cache.AuthCacheService;
-import jakarta.annotation.Resource;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.core.Authentication;
@@ -10,8 +9,12 @@ import org.springframework.security.core.Authentication;
  * iam角色--表达式处理器
  */
 public class IamMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
-    @Resource
-    private AuthCacheService authCacheService;
+
+    private final AuthCacheService authCacheService;
+
+    public IamMethodSecurityExpressionHandler(AuthCacheService authCacheService) {
+        this.authCacheService = authCacheService;
+    }
 
     @Override
     protected IamSecurityExpressionRoot createSecurityExpressionRoot(Authentication authentication,

--- a/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/MethodSecurityConfig.java
+++ b/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/MethodSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.xrcgs.auth.security;
+
+import com.xrcgs.common.cache.AuthCacheService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Method security configuration that wires a custom expression handler.
+ */
+@Configuration
+@EnableMethodSecurity
+public class MethodSecurityConfig {
+
+    @Bean
+    public MethodSecurityExpressionHandler methodSecurityExpressionHandler(AuthCacheService authCacheService) {
+        return new IamMethodSecurityExpressionHandler(authCacheService);
+    }
+}


### PR DESCRIPTION
## Summary
- add MethodSecurityConfig to expose custom IamMethodSecurityExpressionHandler bean
- inject AuthCacheService into IamMethodSecurityExpressionHandler and enable method security via configuration
- remove `@EnableMethodSecurity` from application entry point

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: spring-boot-dependencies:pom:3.4.7, Network is unreachable)*
- `mvn -q -pl xrcgs-boot spring-boot:run` *(fails: Non-resolvable import POM: spring-boot-dependencies:pom:3.4.7, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3133fe8c8321ad5a8c8af3a15fe2