### PR TITLE
Add MethodSecurityConfigurer bean

### DIFF
--- a/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/MethodSecurityConfig.java
+++ b/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/MethodSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.MethodSecurityConfigurer;
 
 /**
  * Method security configuration that wires a custom expression handler.
@@ -16,5 +17,10 @@ public class MethodSecurityConfig {
     @Bean
     public MethodSecurityExpressionHandler methodSecurityExpressionHandler(AuthCacheService authCacheService) {
         return new IamMethodSecurityExpressionHandler(authCacheService);
+    }
+
+    @Bean
+    public MethodSecurityConfigurer methodSecurityConfigurer(AuthCacheService authCacheService) {
+        return builder -> builder.expressionHandler(methodSecurityExpressionHandler(authCacheService));
     }
 }


### PR DESCRIPTION
## Summary
- Wire custom `IamMethodSecurityExpressionHandler` into method security by exposing a `MethodSecurityConfigurer` bean.

## Testing
- `mvn -q -pl xrcgs-module-auth -am test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc36c1d4348321ba7c396090a3493c