### PR TITLE
feat(auth): add PermChecker bean for permission checks

### DIFF
--- a/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/PermChecker.java
+++ b/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/PermChecker.java
@@ -1,0 +1,31 @@
+package com.xrcgs.auth.security;
+
+import com.xrcgs.common.cache.AuthCacheService;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bean for checking permissions in PreAuthorize expressions.
+ */
+@Component("permChecker")
+public class PermChecker {
+
+    private final AuthCacheService authCacheService;
+
+    public PermChecker(AuthCacheService authCacheService) {
+        this.authCacheService = authCacheService;
+    }
+
+    /**
+     * Check whether the given authentication has the specified permission.
+     *
+     * @param authentication current authentication
+     * @param targetPerm     permission to check
+     * @return true if permitted
+     */
+    public boolean hasPerm(Authentication authentication, String targetPerm) {
+        IamSecurityExpressionRoot root = new IamSecurityExpressionRoot(authentication, authCacheService);
+        return root.hasPerm(targetPerm);
+    }
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DictController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DictController.java
@@ -37,7 +37,7 @@ public class DictController {
 
     /** 字典项分页：按 typeCode + label 模糊 */
     @GetMapping("/item/page")
-    @PreAuthorize("hasPerm('iam:dict:item:list')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:item:list')")
     public com.xrcgs.common.core.R<Page<SysDictItem>> itemPage(
             @Valid DictItemPageQuery q,
             @RequestParam(defaultValue = "1") long pageNo,
@@ -47,7 +47,7 @@ public class DictController {
 
     @PostMapping("/type")
     @OpLog("新增字典类型")
-    @PreAuthorize("hasPerm('iam:dict:type:create')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:type:create')")
     public R<Long> createType(@Valid @RequestBody SysDictType type) {
         Long id = dictService.createType(type);
         return R.ok(id);
@@ -55,7 +55,7 @@ public class DictController {
 
     @PutMapping("/type/{id}")
     @OpLog("修改字典类型")
-    @PreAuthorize("hasPerm('iam:dict:type:update')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:type:update')")
     public R<Boolean> updateType(@PathVariable @NotNull Long id,
                                  @Valid @RequestBody SysDictType type) {
         type.setId(id);
@@ -65,7 +65,7 @@ public class DictController {
 
     @DeleteMapping("/type/{id}")
     @OpLog("删除字典类型")
-    @PreAuthorize("hasPerm('iam:dict:type:delete')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:type:delete')")
     public R<Boolean> removeType(@PathVariable @NotNull Long id) {
         dictService.removeType(id);
         return R.ok(true);
@@ -75,7 +75,7 @@ public class DictController {
 
     @PostMapping("/item")
     @OpLog("新增字典项")
-    @PreAuthorize("hasPerm('iam:dict:item:create')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:item:create')")
     public R<Long> createItem(@Valid @RequestBody SysDictItem item) {
         Long id = dictService.createItem(item);
         return R.ok(id);
@@ -83,7 +83,7 @@ public class DictController {
 
     @PutMapping("/item/{id}")
     @OpLog("修改字典项")
-    @PreAuthorize("hasPerm('iam:dict:item:update')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:item:update')")
     public R<Boolean> updateItem(@PathVariable @NotNull Long id,
                                  @Valid @RequestBody SysDictItem item) {
         item.setId(id);
@@ -93,7 +93,7 @@ public class DictController {
 
     @DeleteMapping("/item/{id}")
     @OpLog("删除字典项")
-    @PreAuthorize("hasPerm('iam:dict:item:delete')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:item:delete')")
     public R<Boolean> removeItem(@PathVariable @NotNull Long id) {
         dictService.removeItem(id);
         return R.ok(true);
@@ -102,7 +102,7 @@ public class DictController {
     /* ---------- 查询：按 typeCode ---------- */
 
     @GetMapping("/{typeCode}")
-    @PreAuthorize("hasPerm('iam:dict:get')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:get')")
     public R<DictVO> getByType(@PathVariable @NotBlank String typeCode) {
         return R.ok(dictService.getByType(typeCode));
     }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
@@ -31,21 +31,21 @@ public class MenuController {
 
     // 列表（支持条件查询）
     @GetMapping("/list")
-    @PreAuthorize("hasPerm('iam:menu:list')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:list')")
     public R<List<SysMenu>> list(@Valid MenuQuery q) {
         return R.ok(menuService.list(q));
     }
 
     // 全量启用态菜单树（前端构建路由用）
     @GetMapping("/tree/all")
-    @PreAuthorize("hasPerm('iam:menu:tree')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:tree')")
     public R<List<MenuTreeVO>> treeAllEnabled() {
         return R.ok(menuService.treeAllEnabled());
     }
 
     // 指定角色的菜单树
     @GetMapping("/tree/{roleId}")
-    @PreAuthorize("hasPerm('iam:menu:tree')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:tree')")
     public R<List<MenuTreeVO>> treeByRole(@PathVariable @NotNull Long roleId) {
         return R.ok(menuService.treeByRole(roleId));
     }
@@ -53,7 +53,7 @@ public class MenuController {
     // 新增菜单
     @PostMapping
     @OpLog("新增菜单")
-    @PreAuthorize("hasPerm('iam:menu:create')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:create')")
     public R<Long> create(@Valid @RequestBody SysMenu menu) {
         Long id = menuService.create(menu);
         return R.ok(id);
@@ -62,7 +62,7 @@ public class MenuController {
     // 修改菜单
     @PutMapping("/{id}")
     @OpLog("修改菜单")
-    @PreAuthorize("hasPerm('iam:menu:update')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:update')")
     public R<Boolean> update(@PathVariable @NotNull Long id,
                              @Valid @RequestBody SysMenu menu) {
         menu.setId(id);
@@ -73,7 +73,7 @@ public class MenuController {
     // 删除菜单（无子节点才能删）
     @DeleteMapping("/{id}")
     @OpLog("删除菜单")
-    @PreAuthorize("hasPerm('iam:menu:delete')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:delete')")
     public R<Boolean> delete(@PathVariable @NotNull Long id) {
         menuService.remove(id);
         return R.ok(true);

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/RoleController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/RoleController.java
@@ -33,7 +33,7 @@ public class RoleController {
 
     // 分页查询
     @GetMapping("/page")
-    @PreAuthorize("hasPerm('iam:role:list')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:list')")
     public R<Page<SysRole>> page(@Valid RolePageQuery q,
                                  @RequestParam(defaultValue = "1") long pageNo,
                                  @RequestParam(defaultValue = "10") long pageSize) {
@@ -44,7 +44,7 @@ public class RoleController {
     // 新增
     @PostMapping
     @OpLog("新增角色")
-    @PreAuthorize("hasPerm('iam:role:create')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:create')")
     public R<Long> create(@Valid @RequestBody RoleUpsertDTO dto) {
         dto.setId(null);
         Long id = roleService.upsert(dto);
@@ -54,7 +54,7 @@ public class RoleController {
     // 修改
     @PutMapping("/{id}")
     @OpLog("修改角色")
-    @PreAuthorize("hasPerm('iam:role:update')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:update')")
     public R<Long> update(@PathVariable @NotNull Long id,
                           @Valid @RequestBody RoleUpsertDTO dto) {
         dto.setId(id);
@@ -65,7 +65,7 @@ public class RoleController {
     // 删除
     @DeleteMapping("/{id}")
     @OpLog("删除角色")
-    @PreAuthorize("hasPerm('iam:role:delete')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:delete')")
     public R<Boolean> delete(@PathVariable @NotNull Long id) {
         roleService.remove(id);
         return R.ok(true);
@@ -73,14 +73,14 @@ public class RoleController {
 
     // 角色拥有的菜单ID
     @GetMapping("/{id}/menu-ids")
-    @PreAuthorize("hasPerm('iam:role:grantMenu')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantMenu')")
     public R<List<Long>> listRoleMenuIds(@PathVariable @NotNull Long id) {
         return R.ok(roleService.listMenuIdsByRole(id));
     }
 
     // 角色拥有的权限ID（独立权限表，可选）
     @GetMapping("/{id}/perm-ids")
-    @PreAuthorize("hasPerm('iam:role:grantPerm')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
     public R<List<Long>> listRolePermIds(@PathVariable @NotNull Long id) {
         return R.ok(roleService.listPermIdsByRole(id));
     }
@@ -88,7 +88,7 @@ public class RoleController {
     // 分配菜单
     @PostMapping("/grant-menus")
     @OpLog("角色授权菜单")
-    @PreAuthorize("hasPerm('iam:role:grantMenu')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantMenu')")
 
     public R<Boolean> grantMenus(@Valid @RequestBody RoleGrantMenuDTO dto) {
         roleService.grantMenus(dto);
@@ -98,7 +98,7 @@ public class RoleController {
     // 分配权限码（独立权限）
     @PostMapping("/grant-perms")
     @OpLog("角色授权权限码")
-    @PreAuthorize("hasPerm('iam:role:grantPerm')")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
     public R<Boolean> grantPerms(@Valid @RequestBody RoleGrantPermDTO dto) {
         roleService.grantPerms(dto);
         return R.ok(true);


### PR DESCRIPTION
## Summary
- add `PermChecker` component to reuse permission logic
- wire controllers to use `@permChecker.hasPerm(authentication, '...')` in `@PreAuthorize`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd258a6dd08321b58a43f64a9312de