### PR TITLE
feat(iam): expose router meta options for menus

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
@@ -49,7 +49,10 @@ public class MenuController {
         return R.ok(menuService.treeByRole(roleId));
     }
 
-    // 新增菜单
+    /**
+     * 新增菜单
+     * 支持接收 routerName、keepAlive、showParent 等前端路由字段
+     */
     @PostMapping
     @OpLog("新增菜单")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:create')")
@@ -58,7 +61,10 @@ public class MenuController {
         return R.ok(id);
     }
 
-    // 修改菜单
+    /**
+     * 修改菜单
+     * 支持接收 routerName、keepAlive、showParent 等前端路由字段
+     */
     @PutMapping("/{id}")
     @OpLog("修改菜单")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:update')")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
@@ -15,8 +15,8 @@ public class SysMenu {
     private Long id;
 
     private Long parentId;
-    private String title;
-    private String routerName;
+    private String title;         // 菜单显示名称
+    private String routerName;    // 前端路由名称
     private String path;
     private String component;
 
@@ -28,9 +28,9 @@ public class SysMenu {
     @TableField("rank")
     private Integer rank;
     @TableField("keep_alive")
-    private Boolean keepAlive;
+    private Boolean keepAlive;    // 是否开启组件缓存
     @TableField("show_parent")
-    private Boolean showParent;
+    private Boolean showParent;   // 面包屑中是否显示父级
     private Integer visible; // 1显示 0隐藏
     private Integer status;  // 1启用 0禁用
 

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuMetaVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuMetaVO.java
@@ -7,9 +7,9 @@ import lombok.Data;
  */
 @Data
 public class MenuMetaVO {
-    private String title;
-    private String icon;
-    private Integer rank;
-    private Boolean keepAlive;
-    private Boolean showParent;
+    private String title;        // 菜单标题
+    private String icon;         // 图标
+    private Integer rank;        // 排序
+    private Boolean keepAlive;   // 组件是否缓存
+    private Boolean showParent;  // 是否显示父级
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
@@ -120,8 +120,9 @@ public class MenuServiceImpl implements MenuService {
             meta.setTitle(menu.getTitle());
             meta.setIcon(menu.getIcon());
             meta.setRank(menu.getRank());
-            meta.setKeepAlive(menu.getKeepAlive());
-            meta.setShowParent(menu.getShowParent());
+            // 前端路由元数据的布尔字段不应为 null，避免客户端解析出错
+            meta.setKeepAlive(Boolean.TRUE.equals(menu.getKeepAlive()));
+            meta.setShowParent(Boolean.TRUE.equals(menu.getShowParent()));
 
             MenuTreeVO node = new MenuTreeVO();
             node.setName(menu.getRouterName());


### PR DESCRIPTION
## Summary
- ensure menu tree meta always carries keepAlive and showParent flags
- document routerName, keepAlive and showParent for menu creation and update endpoints

## Testing
- `mvn -q -pl xrcgs-module-iam -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c575a8995c83219ecc317d8456c2a7