### PR TITLE
feat(iam): expose router meta options for menus

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
@@ -49,7 +49,10 @@ public class MenuController {
         return R.ok(menuService.treeByRole(roleId));
     }
 
-    // 新增菜单
+    /**
+     * 新增菜单
+     * 支持接收 routerName、keepAlive、showParent 等前端路由字段
+     */
     @PostMapping
     @OpLog("新增菜单")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:create')")
@@ -58,7 +61,10 @@ public class MenuController {
         return R.ok(id);
     }
 
-    // 修改菜单
+    /**
+     * 修改菜单
+     * 支持接收 routerName、keepAlive、showParent 等前端路由字段
+     */
     @PutMapping("/{id}")
     @OpLog("修改菜单")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:menu:update')")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
@@ -15,8 +15,8 @@ public class SysMenu {
     private Long id;
 
     private Long parentId;
-    private String title;
-    private String routerName;
+    private String title;         // 菜单显示名称
+    private String routerName;    // 前端路由名称
     private String path;
     private String component;
 
@@ -28,16 +28,16 @@ public class SysMenu {
     @TableField("rank")
     private Integer rank;
     @TableField("keep_alive")
-    private Boolean keepAlive;
+    private Boolean keepAlive;    // 是否开启组件缓存
     @TableField("show_parent")
-    private Boolean showParent;
+    private Boolean showParent;   // 面包屑中是否显示父级
     private Integer visible; // 1显示 0隐藏
     private Integer status;  // 1启用 0禁用
 
-    @TableField(fill = FieldFill.INSERT)
+    @TableField(value = "created_at", fill = FieldFill.INSERT)
     private LocalDateTime createTime;
 
-    @TableField(fill = FieldFill.INSERT_UPDATE)
+    @TableField(value = "updated_at", fill = FieldFill.INSERT_UPDATE)
     private LocalDateTime updateTime;
 
     @TableLogic(value = "0", delval = "1")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuMetaVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuMetaVO.java
@@ -7,9 +7,9 @@ import lombok.Data;
  */
 @Data
 public class MenuMetaVO {
-    private String title;
-    private String icon;
-    private Integer rank;
-    private Boolean keepAlive;
-    private Boolean showParent;
+    private String title;        // 菜单标题
+    private String icon;         // 图标
+    private Integer rank;        // 排序
+    private Boolean keepAlive;   // 组件是否缓存
+    private Boolean showParent;  // 是否显示父级
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
@@ -120,8 +120,9 @@ public class MenuServiceImpl implements MenuService {
             meta.setTitle(menu.getTitle());
             meta.setIcon(menu.getIcon());
             meta.setRank(menu.getRank());
-            meta.setKeepAlive(menu.getKeepAlive());
-            meta.setShowParent(menu.getShowParent());
+            // 前端路由元数据的布尔字段不应为 null，避免客户端解析出错
+            meta.setKeepAlive(Boolean.TRUE.equals(menu.getKeepAlive()));
+            meta.setShowParent(Boolean.TRUE.equals(menu.getShowParent()));
 
             MenuTreeVO node = new MenuTreeVO();
             node.setName(menu.getRouterName());

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
@@ -18,15 +18,15 @@
         <result property="showParent" column="show_parent"/>
         <result property="visible"    column="visible"/>
         <result property="status"     column="status"/>
-        <result property="createTime" column="create_time"/>
-        <result property="updateTime" column="update_time"/>
+        <result property="createTime" column="created_at"/>
+        <result property="updateTime" column="updated_at"/>
         <result property="delFlag"   column="del_flag"/>
     </resultMap>
 
     <select id="selectListByQuery" resultMap="MenuMap">
         SELECT id, parent_id, title, router_name, path, component, type, perms,
                icon, rank, keep_alive, show_parent, visible, status,
-               create_time, update_time, del_flag
+               created_at, updated_at, del_flag
         FROM sys_menu
         WHERE del_flag = 0
         <if test="q != null">
@@ -55,7 +55,7 @@
     <select id="selectByRoleId" resultMap="MenuMap">
         SELECT m.id, m.parent_id, m.title, m.router_name, m.path, m.component,
                m.type, m.perms, m.icon, m.rank, m.keep_alive, m.show_parent,
-               m.visible, m.status, m.create_time, m.update_time, m.del_flag
+               m.visible, m.status, m.created_at, m.updated_at, m.del_flag
         FROM sys_menu m
                  INNER JOIN sys_role_menu rm ON rm.menu_id = m.id
         WHERE rm.role_id = #{roleId} AND m.del_flag = 0


### PR DESCRIPTION
## Summary
- ensure menu tree meta always carries keepAlive and showParent flags
- document routerName, keepAlive and showParent for menu creation and update endpoints
- align sys_menu timestamp mappings with created_at/updated_at columns

## Testing
- `mvn -q -pl xrcgs-module-iam -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c575a8995c83219ecc317d8456c2a7