### PR TITLE
feat(iam): add menu tree lookup by role codes

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
@@ -49,6 +49,12 @@ public class MenuController {
         return R.ok(menuService.treeByRole(roleId));
     }
 
+    // 根据角色编码集合获取菜单树
+    @PostMapping("/tree/by-codes")
+    public R<List<MenuTreeVO>> treeByRoleCodes(@RequestBody List<String> roleCodes) {
+        return R.ok(menuService.treeByRoleCodes(roleCodes));
+    }
+
     /**
      * 新增菜单
      * 支持接收 routerName、keepAlive、showParent 等前端路由字段

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysMenuMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysMenuMapper.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface SysMenuMapper extends BaseMapper<SysMenu> {
     List<SysMenu> selectListByQuery(@Param("q") MenuQuery q);
     List<SysMenu> selectByRoleId(@Param("roleId") Long roleId);
+    List<SysMenu> selectByRoleIds(@Param("roleIds") List<Long> roleIds);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysRoleMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysRoleMapper.java
@@ -6,6 +6,9 @@ import com.xrcgs.iam.entity.SysRole;
 import com.xrcgs.iam.model.query.RolePageQuery;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 public interface SysRoleMapper extends BaseMapper<SysRole> {
     Page<SysRole> selectPage(Page<SysRole> page, @Param("q") RolePageQuery q);
+    List<Long> selectIdsByCodes(@Param("codes") List<String> codes);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/MenuService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/MenuService.java
@@ -13,5 +13,6 @@ public interface MenuService {
 
     List<MenuTreeVO> treeAllEnabled();       // 全部启用态
     List<MenuTreeVO> treeByRole(Long roleId); // 指定角色
+    List<MenuTreeVO> treeByRoleCodes(List<String> roleCodes); // 通过角色编码集合
     List<SysMenu> list(MenuQuery q);
 }

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
@@ -62,4 +62,18 @@
         ORDER BY m.rank ASC, m.id ASC
     </select>
 
+    <select id="selectByRoleIds" resultMap="MenuMap">
+        SELECT DISTINCT m.id, m.parent_id, m.title, m.router_name, m.path, m.component,
+               m.type, m.perms, m.icon, m.rank, m.keep_alive, m.show_parent,
+               m.visible, m.status, m.created_at, m.updated_at, m.del_flag
+        FROM sys_menu m
+                 INNER JOIN sys_role_menu rm ON rm.menu_id = m.id
+        WHERE rm.role_id IN
+        <foreach collection="roleIds" item="rid" open="(" separator="," close=")">
+            #{rid}
+        </foreach>
+          AND m.del_flag = 0
+        ORDER BY m.rank ASC, m.id ASC
+    </select>
+
 </mapper>

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysRoleMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysRoleMapper.xml
@@ -28,4 +28,13 @@
         ORDER BY sort_no ASC, id DESC
     </select>
 
+    <select id="selectIdsByCodes" resultType="java.lang.Long">
+        SELECT id FROM sys_role
+        WHERE code IN
+        <foreach collection="codes" item="code" open="(" separator="," close=")">
+            #{code}
+        </foreach>
+          AND del_flag = 0
+    </select>
+
 </mapper>


### PR DESCRIPTION
## Summary
- add `/tree/by-codes` endpoint to fetch menu tree by role codes
- support role code lookup in service and mappers
- implement menu retrieval by multiple role IDs

## Testing
- `mvn -q -pl xrcgs-module-iam -am test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:3.4.7)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a04cc93883219b2ccf5d0269666b