### PR TITLE
feat(iam): return flat menu list for role codes

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.xrcgs.iam.controller;
 
 import com.xrcgs.iam.entity.SysMenu;
 import com.xrcgs.iam.model.query.MenuQuery;
+import com.xrcgs.iam.model.vo.MenuRouteVO;
 import com.xrcgs.iam.model.vo.MenuTreeVO;
 import com.xrcgs.iam.service.MenuService;
 // ↓↓↓ 按你项目实际包名修改
@@ -50,10 +51,10 @@ public class MenuController {
         return R.ok(menuService.treeByRole(roleId));
     }
 
-    // 根据角色编码集合获取菜单树
+    // 根据角色编码集合获取菜单列表（平铺）
     @PostMapping("/tree/by-codes")
-    public R<List<MenuTreeVO>> treeByRoleCodes(@RequestBody List<String> roleCodes) {
-        return R.ok(menuService.treeByRoleCodes(roleCodes));
+    public List<MenuRouteVO> listByRoleCodes(@RequestBody List<String> roleCodes) {
+        return menuService.listByRoleCodes(roleCodes);
     }
 
     /**

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuRouteVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/MenuRouteVO.java
@@ -1,0 +1,20 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+/**
+ * 平铺菜单路由信息
+ */
+@Data
+public class MenuRouteVO {
+    private Long id;
+    private Long parentId;
+    private String path;
+    private String name;
+    private String component;
+    private String title;
+    private String icon;
+    private Integer rank;
+    private Boolean keepAlive;
+    private Boolean showParent;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/MenuService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/MenuService.java
@@ -2,6 +2,7 @@ package com.xrcgs.iam.service;
 
 import com.xrcgs.iam.entity.SysMenu;
 import com.xrcgs.iam.model.query.MenuQuery;
+import com.xrcgs.iam.model.vo.MenuRouteVO;
 import com.xrcgs.iam.model.vo.MenuTreeVO;
 
 import java.util.List;
@@ -13,6 +14,6 @@ public interface MenuService {
 
     List<MenuTreeVO> treeAllEnabled();       // 全部启用态
     List<MenuTreeVO> treeByRole(Long roleId); // 指定角色
-    List<MenuTreeVO> treeByRoleCodes(List<String> roleCodes); // 通过角色编码集合
+    List<MenuRouteVO> listByRoleCodes(List<String> roleCodes); // 通过角色编码集合
     List<SysMenu> list(MenuQuery q);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/MenuServiceImpl.java
@@ -10,6 +10,7 @@ import com.xrcgs.iam.mapper.SysRoleMapper;
 import com.xrcgs.iam.mapper.SysRoleMenuMapper;
 import com.xrcgs.iam.model.query.MenuQuery;
 import com.xrcgs.iam.model.vo.MenuMetaVO;
+import com.xrcgs.iam.model.vo.MenuRouteVO;
 import com.xrcgs.iam.model.vo.MenuTreeVO;
 import com.xrcgs.iam.service.MenuService;
 import com.xrcgs.common.cache.AuthCacheService;
@@ -102,7 +103,7 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
-    public List<MenuTreeVO> treeByRoleCodes(List<String> roleCodes) {
+    public List<MenuRouteVO> listByRoleCodes(List<String> roleCodes) {
         if (roleCodes == null || roleCodes.isEmpty()) {
             return Collections.emptyList();
         }
@@ -119,7 +120,20 @@ public class MenuServiceImpl implements MenuService {
         }
         List<SysMenu> list = new ArrayList<>(map.values());
         list.sort(Comparator.comparing(SysMenu::getRank).thenComparing(SysMenu::getId));
-        return buildTree(list);
+        return list.stream().map(menu -> {
+            MenuRouteVO vo = new MenuRouteVO();
+            vo.setId(menu.getId());
+            vo.setParentId(menu.getParentId());
+            vo.setPath(menu.getPath());
+            vo.setName(menu.getRouterName());
+            vo.setComponent(menu.getComponent());
+            vo.setTitle(menu.getTitle());
+            vo.setIcon(menu.getIcon());
+            vo.setRank(menu.getRank());
+            vo.setKeepAlive(Boolean.TRUE.equals(menu.getKeepAlive()));
+            vo.setShowParent(Boolean.TRUE.equals(menu.getShowParent()));
+            return vo;
+        }).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return flattened menu data for `/tree/by-codes` endpoint
- expose new `MenuRouteVO` and service method to support flat list

## Testing
- `mvn -q -pl xrcgs-module-iam -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.4.7)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ac54661483219aca209e3f3eb37a