### PR TITLE
feat(iam): add dept ddl and path docs

### DIFF
--- a/xrcgs-module-iam/src/main/resources/db/001_create_sys_dept.sql
+++ b/xrcgs-module-iam/src/main/resources/db/001_create_sys_dept.sql
@@ -1,0 +1,33 @@
+-- -----------------------------------------------------------------------------
+-- Schema: sys_dept
+-- -----------------------------------------------------------------------------
+-- 部门（组织架构）表，采用物化路径（materialized path）存储整棵树的上下级关系。
+-- path 字段以「/」分隔 ID，例如「/1/」「/1/3/」「/1/3/8/」。
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `sys_dept` (
+    `id`              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键 ID',
+    `parent_id`       BIGINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '父部门 ID，0 表示顶级',
+    `path`            VARCHAR(512)    NOT NULL COMMENT '物化路径 /1/3/5/，用于层级查询',
+    `name`            VARCHAR(100)    NOT NULL COMMENT '部门名称',
+    `code`            VARCHAR(100)             DEFAULT NULL COMMENT '部门编码，选填',
+    `status`          TINYINT         NOT NULL DEFAULT 1 COMMENT '状态：1=启用，0=禁用',
+    `sort_no`         INT             NOT NULL DEFAULT 0 COMMENT '排序号，越小越靠前',
+    `leader_user_id`  BIGINT UNSIGNED          DEFAULT NULL COMMENT '负责人用户 ID',
+    `phone`           VARCHAR(30)              DEFAULT NULL COMMENT '联系电话',
+    `email`           VARCHAR(100)             DEFAULT NULL COMMENT '联系邮箱',
+    `remark`          VARCHAR(255)             DEFAULT NULL COMMENT '备注',
+    `create_by`       BIGINT UNSIGNED          DEFAULT NULL COMMENT '创建人',
+    `create_time`     DATETIME         NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`       BIGINT UNSIGNED          DEFAULT NULL COMMENT '更新人',
+    `update_time`     DATETIME         NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `del_flag`        TINYINT          NOT NULL DEFAULT 0 COMMENT '逻辑删除：0=在用，1=已删除',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_sys_dept_path` (`path`),
+    UNIQUE KEY `uk_sys_dept_parent_name` (`parent_id`, `name`),
+    KEY `idx_sys_dept_parent_id` (`parent_id`),
+    KEY `idx_sys_dept_sort_no` (`parent_id`, `sort_no`),
+    CONSTRAINT `chk_sys_dept_path_format` CHECK (`path` REGEXP '^(/[0-9]+)+/$')
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci
+  COMMENT '系统部门';

--- a/xrcgs-module-iam/src/main/resources/db/002_alter_sys_user_role_add_dept_scope.sql
+++ b/xrcgs-module-iam/src/main/resources/db/002_alter_sys_user_role_add_dept_scope.sql
@@ -1,0 +1,43 @@
+-- -----------------------------------------------------------------------------
+-- Alter: sys_user, sys_role
+-- -----------------------------------------------------------------------------
+-- 为用户和角色表补齐部门（dept_id、extra_dept_ids）及数据范围（data_scope、data_scope_ext）字段。
+-- data_scope_ext / extra_dept_ids 使用 JSON 存储，方便直接解析为数组。
+-- -----------------------------------------------------------------------------
+
+-- sys_user --------------------------------------------------------------------
+ALTER TABLE `sys_user`
+    ADD COLUMN IF NOT EXISTS `dept_id` BIGINT UNSIGNED NULL COMMENT '主部门 ID' AFTER `nickname`,
+    ADD COLUMN IF NOT EXISTS `extra_dept_ids` JSON NULL COMMENT '附加部门 ID 列表（JSON 数组，如 [1,2,3]）' AFTER `dept_id`,
+    ADD COLUMN IF NOT EXISTS `data_scope` VARCHAR(32) NOT NULL DEFAULT 'SELF' COMMENT '数据范围：ALL/DEPT/DEPT_AND_CHILD/SELF/CUSTOM' AFTER `extra_dept_ids`,
+    ADD COLUMN IF NOT EXISTS `data_scope_ext` JSON NULL COMMENT '扩展数据范围，CUSTOM 时存 JSON 数组' AFTER `data_scope`;
+
+ALTER TABLE `sys_user`
+    ADD INDEX IF NOT EXISTS `idx_sys_user_dept_id` (`dept_id`);
+
+-- 保障 JSON 类型（如历史库中为 VARCHAR 时自动改为 JSON）。
+ALTER TABLE `sys_user`
+    MODIFY COLUMN `extra_dept_ids` JSON NULL COMMENT '附加部门 ID 列表（JSON 数组，如 [1,2,3]）',
+    MODIFY COLUMN `data_scope_ext` JSON NULL COMMENT '扩展数据范围，CUSTOM 时存 JSON 数组';
+
+UPDATE `sys_user`
+SET `data_scope` = 'SELF'
+WHERE `data_scope` IS NULL;
+
+-- sys_role --------------------------------------------------------------------
+ALTER TABLE `sys_role`
+    ADD COLUMN IF NOT EXISTS `dept_id` BIGINT UNSIGNED NULL COMMENT '归属部门 ID' AFTER `name`,
+    ADD COLUMN IF NOT EXISTS `extra_dept_ids` JSON NULL COMMENT '附加部门 ID 列表（JSON 数组）' AFTER `dept_id`,
+    ADD COLUMN IF NOT EXISTS `data_scope` VARCHAR(32) NOT NULL DEFAULT 'SELF' COMMENT '数据范围：ALL/DEPT/DEPT_AND_CHILD/SELF/CUSTOM' AFTER `extra_dept_ids`,
+    ADD COLUMN IF NOT EXISTS `data_scope_ext` JSON NULL COMMENT '扩展数据范围，CUSTOM 时存 JSON 数组' AFTER `data_scope`;
+
+ALTER TABLE `sys_role`
+    ADD INDEX IF NOT EXISTS `idx_sys_role_dept_id` (`dept_id`);
+
+ALTER TABLE `sys_role`
+    MODIFY COLUMN `extra_dept_ids` JSON NULL COMMENT '附加部门 ID 列表（JSON 数组）',
+    MODIFY COLUMN `data_scope_ext` JSON NULL COMMENT '扩展数据范围，CUSTOM 时存 JSON 数组';
+
+UPDATE `sys_role`
+SET `data_scope` = 'SELF'
+WHERE `data_scope` IS NULL;

--- a/xrcgs-module-iam/src/main/resources/db/003_seed_sys_dept_and_path_backfill.sql
+++ b/xrcgs-module-iam/src/main/resources/db/003_seed_sys_dept_and_path_backfill.sql
@@ -1,0 +1,66 @@
+-- -----------------------------------------------------------------------------
+-- Seed data & helper scripts for sys_dept
+-- -----------------------------------------------------------------------------
+-- 1. 示例部门初始化（可重复执行，使用 ON DUPLICATE KEY UPDATE 保持幂等）。
+-- 2. 部门改动示例（调整父子关系时同步维护 path）。
+-- 3. 通用 path 回填脚本（当 path 缺失或批量导入后需要重算时使用）。
+-- -----------------------------------------------------------------------------
+
+SET @now := NOW();
+
+INSERT INTO `sys_dept` (`id`, `parent_id`, `path`, `name`, `code`, `status`, `sort_no`, `create_time`, `update_time`)
+VALUES
+    (1, 0, '/1/',  '集团总部',      'HQ',        1, 10, @now, @now),
+    (2, 1, '/1/2/', '研发中心',      'RND',       1, 20, @now, @now),
+    (3, 1, '/1/3/', '市场部',        'MKT',       1, 30, @now, @now),
+    (4, 2, '/1/2/4/', '平台研发一部', 'RND-PLAT',  1, 40, @now, @now),
+    (5, 2, '/1/2/5/', '平台研发二部', 'RND-MOB',   1, 50, @now, @now)
+ON DUPLICATE KEY UPDATE
+    `parent_id`  = VALUES(`parent_id`),
+    `path`       = VALUES(`path`),
+    `name`       = VALUES(`name`),
+    `code`       = VALUES(`code`),
+    `status`     = VALUES(`status`),
+    `sort_no`    = VALUES(`sort_no`),
+    `update_time`= @now;
+
+-- 调整部门父级示例：把「平台研发二部」移动到「市场部」下面。
+-- 注意：path 必须同步更新为 parent.path + 当前 id + '/'.
+UPDATE `sys_dept` AS child
+JOIN `sys_dept` AS new_parent ON new_parent.id = 3
+SET
+    child.parent_id = new_parent.id,
+    child.path      = CONCAT(new_parent.path, child.id, '/'),
+    child.update_time = NOW(),
+    child.update_by   = 1
+WHERE child.id = 5;
+
+-- -----------------------------------------------------------------------------
+-- 通用 path 回填脚本
+--  - 场景：1）老数据 path 缺失/格式不正确；2）使用脚本导入大量部门后统一刷新。
+--  - 逻辑：从顶级部门（parent_id=0 或 parent_id IS NULL）开始向下递归，拼接父级 path。
+-- -----------------------------------------------------------------------------
+WITH RECURSIVE dept_tree AS (
+    SELECT
+        d.id,
+        d.parent_id,
+        CAST(CONCAT('/', d.id, '/') AS CHAR(512)) AS new_path
+    FROM `sys_dept` AS d
+    WHERE d.parent_id = 0 OR d.parent_id IS NULL
+
+    UNION ALL
+
+    SELECT
+        child.id,
+        child.parent_id,
+        CAST(CONCAT(parent.new_path, child.id, '/') AS CHAR(512)) AS new_path
+    FROM `sys_dept` AS child
+    JOIN dept_tree AS parent ON child.parent_id = parent.id
+)
+UPDATE `sys_dept` AS d
+JOIN dept_tree AS t ON d.id = t.id
+SET d.path = t.new_path,
+    d.update_time = NOW();
+
+-- 对于层级存在孤儿节点（父级不存在）的情况，可单独处理：
+-- UPDATE `sys_dept` SET `path` = CONCAT('/', `id`, '/') WHERE `parent_id` NOT IN (SELECT `id` FROM `sys_dept`);

--- a/xrcgs-module-iam/src/main/resources/db/README.md
+++ b/xrcgs-module-iam/src/main/resources/db/README.md
@@ -1,0 +1,34 @@
+# IAM 模块数据库脚本
+
+本目录收纳 IAM 模块相关的结构初始化与示例脚本：
+
+- `001_create_sys_dept.sql`：创建部门表 `sys_dept`，使用物化路径维护组织层级。
+- `002_alter_sys_user_role_add_dept_scope.sql`：为 `sys_user`、`sys_role` 补齐部门/数据范围字段，并确保 JSON 字段类型正确。
+- `003_seed_sys_dept_and_path_backfill.sql`：示例部门数据、部门迁移示例及通用 path 回填脚本。
+
+## `path` 字段的物化路径语义
+
+`sys_dept.path` 采用“物化路径 (materialized path)”方案表示上下级关系，格式约定如下：
+
+1. **以 `/` 作为分隔符，并同时作为前缀与后缀**。例如根部门 ID=1 的 path 为 `/1/`，其子部门 ID=2 的 path 为 `/1/2/`。
+2. **完整路径由父节点 path 加上当前部门 ID 拼接得到**：`child.path = CONCAT(parent.path, child.id, '/')`。
+3. 依赖 path 可以快速完成如下查询：
+   - `SELECT * FROM sys_dept WHERE path LIKE '/1/%'` 查询所有属于“集团总部”的部门。
+   - `ORDER BY path` 即可按层级输出结构化列表。
+4. `chk_sys_dept_path_format` 检查约束会校验 path 必须满足上述格式（至少包含一个 ID，且均为数字）。
+
+> **两段式插入建议**：若通过自增主键插入，可先写入一个临时唯一 path（例如 `CONCAT('#pending#', UUID())`），获取自增 ID 后再执行 `UPDATE` 将 path 改写为父级 path + ID 的正式格式。参见 `003_seed_sys_dept_and_path_backfill.sql` 中的示例。
+
+## 示例脚本说明
+
+- **初始化组织架构**：执行 `003_seed_sys_dept_and_path_backfill.sql` 顶部的 INSERT 语句，可重复执行（`ON DUPLICATE KEY UPDATE` 保证幂等），用于快速造一份标准数据。
+- **迁移部门**：脚本中提供了将“平台研发二部”改挂到“市场部”的 `UPDATE` 示范，展示修改父级时同步刷新 path 的方式。
+- **回填 path**：当导入老数据或 path 失真时，执行同一脚本中的 `WITH RECURSIVE` 回填语句，可一次性重新计算所有路径；必要时对孤儿节点再执行最后的补丁语句。
+
+## 本地验证建议
+
+1. 在本地数据库（例如 MySQL 8.0）中新建 schema，并按顺序执行 `001`、`002`、`003` 三个脚本。
+2. 使用 Navicat/Datagrip 等客户端检查：
+   - `sys_dept` 包含 `parent_id`、`path`、`chk_sys_dept_path_format` 约束以及 `uk_sys_dept_path` 等索引；
+   - `sys_user`、`sys_role` 出现新的 JSON 字段（`extra_dept_ids`、`data_scope_ext`）且 `dept_id` 索引可见。
+3. 按需执行回填脚本，再查询 `SELECT id, parent_id, path FROM sys_dept ORDER BY path;`，确认路径已正确落地。


### PR DESCRIPTION
## Summary
- add `sys_dept` table definition with materialized path indexes and constraint
- extend `sys_user` and `sys_role` tables with department/data scope JSON columns
- provide seed/backfill scripts and README documenting path semantics and verification steps

## Testing
- not run (SQL DDL only)


------
https://chatgpt.com/codex/tasks/task_e_68cc37fd13c4832196b84bfcd1ac8bb3