### PR TITLE
feat(iam): add department management endpoints and service

### DIFF
--- a/xrcgs-common/src/main/java/com/xrcgs/common/constants/IamCacheKeys.java
+++ b/xrcgs-common/src/main/java/com/xrcgs/common/constants/IamCacheKeys.java
@@ -14,4 +14,10 @@ public interface IamCacheKeys {
     // 字典缓存：按 typeCode
     String DICT_TYPE = "dict:"; // + {typeCode}
 
+    // 部门树版本号，用于通知前端刷新组织架构缓存
+    String DEPT_TREE_VERSION = "iam:dept:treeVersion";
+
+    // 部门数据范围缓存前缀，+ {deptId}
+    String DEPT_SCOPE = "iam:dept:scope:";
+
 }

--- a/xrcgs-module-iam/pom.xml
+++ b/xrcgs-module-iam/pom.xml
@@ -62,5 +62,11 @@
             <artifactId>xrcgs-module-syslog</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DeptController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DeptController.java
@@ -1,0 +1,64 @@
+package com.xrcgs.iam.controller;
+
+import com.xrcgs.common.core.R;
+import com.xrcgs.iam.model.dto.DeptUpsertDTO;
+import com.xrcgs.iam.model.vo.DeptTreeVO;
+import com.xrcgs.iam.model.vo.DeptVO;
+import com.xrcgs.iam.service.DeptService;
+import com.xrcgs.syslog.annotation.OpLog;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 部门管理接口
+ */
+@Validated
+@RestController
+@RequestMapping("/api/iam/dept")
+@RequiredArgsConstructor
+public class DeptController {
+
+    private final DeptService deptService;
+
+    @GetMapping("/tree")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:tree')")
+    public R<List<DeptTreeVO>> tree(@RequestParam(value = "status", required = false) Integer status) {
+        return R.ok(deptService.tree(status));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:list')")
+    public R<DeptVO> detail(@PathVariable @NotNull Long id) {
+        return R.ok(deptService.detail(id));
+    }
+
+    @PostMapping
+    @OpLog("新增部门")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:create')")
+    public R<Long> create(@Valid @RequestBody DeptUpsertDTO dto) {
+        return R.ok(deptService.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    @OpLog("修改部门")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:update')")
+    public R<Boolean> update(@PathVariable @NotNull Long id,
+                             @Valid @RequestBody DeptUpsertDTO dto) {
+        deptService.update(id, dto);
+        return R.ok(true);
+    }
+
+    @DeleteMapping("/{id}")
+    @OpLog("删除部门")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:delete')")
+    public R<Boolean> delete(@PathVariable @NotNull Long id) {
+        deptService.delete(id);
+        return R.ok(true);
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysDept.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysDept.java
@@ -1,0 +1,56 @@
+package com.xrcgs.iam.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 系统部门实体
+ */
+@Data
+@TableName("sys_dept")
+public class SysDept {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private Long parentId;
+
+    private String path;
+
+    private String name;
+
+    private String code;
+
+    private Integer status;
+
+    @TableField("sort_no")
+    private Integer sortNo;
+
+    private Long leaderUserId;
+
+    private String phone;
+
+    private String email;
+
+    private String remark;
+
+    private Long createBy;
+
+    @TableField(value = "create_time", fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+
+    private Long updateBy;
+
+    @TableField(value = "update_time", fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+
+    @TableLogic(value = "0", delval = "1")
+    private Integer delFlag;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysDeptMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysDeptMapper.java
@@ -1,0 +1,22 @@
+package com.xrcgs.iam.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.xrcgs.iam.entity.SysDept;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface SysDeptMapper extends BaseMapper<SysDept> {
+
+    List<SysDept> selectChildren(@Param("parentId") Long parentId);
+
+    List<SysDept> selectByPathPrefix(@Param("pathPrefix") String pathPrefix);
+
+    List<Long> selectIdsByPathPrefix(@Param("pathPrefix") String pathPrefix);
+
+    int updatePathPrefix(@Param("oldPath") String oldPath, @Param("newPath") String newPath);
+
+    Long countChildren(@Param("parentId") Long parentId);
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/DeptUpsertDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/DeptUpsertDTO.java
@@ -1,0 +1,39 @@
+package com.xrcgs.iam.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 部门新增/修改 DTO
+ */
+@Data
+public class DeptUpsertDTO {
+
+    /**
+     * 父部门 ID，0 表示顶级
+     */
+    private Long parentId;
+
+    @NotBlank(message = "部门名称不能为空")
+    @Size(max = 100, message = "部门名称长度不能超过100个字符")
+    private String name;
+
+    @Size(max = 100, message = "部门编码长度不能超过100个字符")
+    private String code;
+
+    private Integer status;
+
+    private Integer sortNo;
+
+    private Long leaderUserId;
+
+    @Size(max = 30, message = "联系电话长度不能超过30个字符")
+    private String phone;
+
+    @Size(max = 100, message = "联系邮箱长度不能超过100个字符")
+    private String email;
+
+    @Size(max = 255, message = "备注长度不能超过255个字符")
+    private String remark;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptTreeVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptTreeVO.java
@@ -1,0 +1,25 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 部门树 VO
+ */
+@Data
+public class DeptTreeVO {
+    private Long id;
+    private Long parentId;
+    private String name;
+    private String code;
+    private Integer status;
+    private Integer sortNo;
+    private String path;
+    private Long leaderUserId;
+    private String phone;
+    private String email;
+    private String remark;
+    private final List<DeptTreeVO> children = new ArrayList<>();
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptVO.java
@@ -1,0 +1,27 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 部门详情 VO
+ */
+@Data
+public class DeptVO {
+    private Long id;
+    private Long parentId;
+    private String path;
+    private String name;
+    private String code;
+    private Integer status;
+    private Integer sortNo;
+    private Long leaderUserId;
+    private String phone;
+    private String email;
+    private String remark;
+    private Long createBy;
+    private LocalDateTime createTime;
+    private Long updateBy;
+    private LocalDateTime updateTime;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DeptService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DeptService.java
@@ -1,0 +1,20 @@
+package com.xrcgs.iam.service;
+
+import com.xrcgs.iam.model.dto.DeptUpsertDTO;
+import com.xrcgs.iam.model.vo.DeptTreeVO;
+import com.xrcgs.iam.model.vo.DeptVO;
+
+import java.util.List;
+
+public interface DeptService {
+
+    Long create(DeptUpsertDTO dto);
+
+    void update(Long id, DeptUpsertDTO dto);
+
+    void delete(Long id);
+
+    DeptVO detail(Long id);
+
+    List<DeptTreeVO> tree(Integer status);
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DeptServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DeptServiceImpl.java
@@ -1,0 +1,276 @@
+package com.xrcgs.iam.service.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.xrcgs.common.constants.IamCacheKeys;
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.mapper.SysDeptMapper;
+import com.xrcgs.iam.model.dto.DeptUpsertDTO;
+import com.xrcgs.iam.model.vo.DeptTreeVO;
+import com.xrcgs.iam.model.vo.DeptVO;
+import com.xrcgs.iam.service.DeptService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DeptServiceImpl implements DeptService {
+
+    private final SysDeptMapper deptMapper;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public List<DeptTreeVO> tree(Integer status) {
+        List<SysDept> list = deptMapper.selectList(
+                Wrappers.<SysDept>lambdaQuery()
+                        .eq(SysDept::getDelFlag, 0)
+                        .eq(status != null, SysDept::getStatus, status)
+                        .orderByAsc(SysDept::getSortNo, SysDept::getId)
+        );
+        if (list == null || list.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return buildTree(list);
+    }
+
+    @Override
+    public DeptVO detail(Long id) {
+        SysDept dept = requireActive(id);
+        return toDetailVO(dept);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Long create(DeptUpsertDTO dto) {
+        Long parentId = normalizeParentId(dto.getParentId());
+        SysDept parent = parentId != null && parentId > 0 ? requireActive(parentId) : null;
+
+        String name = normalize(dto.getName());
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("部门名称不能为空");
+        }
+        ensureNameUnique(parentId, name, null);
+
+        SysDept entity = new SysDept();
+        entity.setParentId(parentId);
+        entity.setName(name);
+        entity.setCode(normalize(dto.getCode()));
+        entity.setStatus(dto.getStatus() != null ? dto.getStatus() : 1);
+        entity.setSortNo(dto.getSortNo() != null ? dto.getSortNo() : 0);
+        entity.setLeaderUserId(dto.getLeaderUserId());
+        entity.setPhone(normalize(dto.getPhone()));
+        entity.setEmail(normalize(dto.getEmail()));
+        entity.setRemark(normalize(dto.getRemark()));
+        entity.setPath(buildPendingPath(parentId));
+
+        deptMapper.insert(entity);
+
+        String newPath = buildPath(parent, entity.getId());
+        entity.setPath(newPath);
+        deptMapper.updateById(entity);
+
+        bumpTreeVersionAndEvict(Collections.singletonList(entity.getId()));
+        return entity.getId();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void update(Long id, DeptUpsertDTO dto) {
+        SysDept current = requireActive(id);
+        Long parentId = normalizeParentId(dto.getParentId());
+        SysDept parent = parentId != null && parentId > 0 ? requireActive(parentId) : null;
+
+        if (Objects.equals(id, parentId)) {
+            throw new IllegalArgumentException("父级部门不能是自身");
+        }
+        if (parent != null && parent.getPath() != null && current.getPath() != null
+                && parent.getPath().startsWith(current.getPath())) {
+            throw new IllegalArgumentException("不能将部门移动到自己的子部门下");
+        }
+
+        String name = normalize(dto.getName());
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("部门名称不能为空");
+        }
+        ensureNameUnique(parentId, name, id);
+
+        SysDept update = new SysDept();
+        update.setId(id);
+        update.setParentId(parentId);
+        update.setName(name);
+        update.setCode(normalize(dto.getCode()));
+        update.setStatus(dto.getStatus() != null ? dto.getStatus() : current.getStatus());
+        update.setSortNo(dto.getSortNo() != null ? dto.getSortNo() : current.getSortNo());
+        update.setLeaderUserId(dto.getLeaderUserId());
+        update.setPhone(normalize(dto.getPhone()));
+        update.setEmail(normalize(dto.getEmail()));
+        update.setRemark(normalize(dto.getRemark()));
+
+        String newPath = buildPath(parent, id);
+        boolean pathChanged = !Objects.equals(newPath, current.getPath());
+        update.setPath(newPath);
+
+        List<Long> affectedIds = deptMapper.selectIdsByPathPrefix(current.getPath());
+        if (affectedIds == null || affectedIds.isEmpty()) {
+            affectedIds = Collections.singletonList(id);
+        }
+        if (pathChanged) {
+            deptMapper.updatePathPrefix(current.getPath(), newPath);
+        }
+        deptMapper.updateById(update);
+
+        bumpTreeVersionAndEvict(affectedIds);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void delete(Long id) {
+        SysDept dept = requireActive(id);
+        Long childCount = deptMapper.countChildren(id);
+        if (childCount != null && childCount > 0) {
+            throw new IllegalStateException("存在子部门，无法删除");
+        }
+        List<Long> affectedIds = deptMapper.selectIdsByPathPrefix(dept.getPath());
+        if (affectedIds == null || affectedIds.isEmpty()) {
+            affectedIds = Collections.singletonList(dept.getId());
+        }
+        deptMapper.deleteById(id);
+        bumpTreeVersionAndEvict(affectedIds);
+    }
+
+    /* ----------------- helpers ----------------- */
+
+    private List<DeptTreeVO> buildTree(List<SysDept> flat) {
+        Map<Long, DeptTreeVO> map = new HashMap<>(flat.size());
+        for (SysDept dept : flat) {
+            DeptTreeVO node = new DeptTreeVO();
+            node.setId(dept.getId());
+            node.setParentId(dept.getParentId());
+            node.setName(dept.getName());
+            node.setCode(dept.getCode());
+            node.setStatus(dept.getStatus());
+            node.setSortNo(dept.getSortNo());
+            node.setPath(dept.getPath());
+            node.setLeaderUserId(dept.getLeaderUserId());
+            node.setPhone(dept.getPhone());
+            node.setEmail(dept.getEmail());
+            node.setRemark(dept.getRemark());
+            map.put(dept.getId(), node);
+        }
+
+        List<DeptTreeVO> roots = new ArrayList<>();
+        for (SysDept dept : flat) {
+            DeptTreeVO node = map.get(dept.getId());
+            Long pid = dept.getParentId();
+            if (pid == null || pid == 0 || !map.containsKey(pid)) {
+                roots.add(node);
+            } else {
+                map.get(pid).getChildren().add(node);
+            }
+        }
+        return roots;
+    }
+
+    private DeptVO toDetailVO(SysDept dept) {
+        DeptVO vo = new DeptVO();
+        vo.setId(dept.getId());
+        vo.setParentId(dept.getParentId());
+        vo.setPath(dept.getPath());
+        vo.setName(dept.getName());
+        vo.setCode(dept.getCode());
+        vo.setStatus(dept.getStatus());
+        vo.setSortNo(dept.getSortNo());
+        vo.setLeaderUserId(dept.getLeaderUserId());
+        vo.setPhone(dept.getPhone());
+        vo.setEmail(dept.getEmail());
+        vo.setRemark(dept.getRemark());
+        vo.setCreateBy(dept.getCreateBy());
+        vo.setCreateTime(dept.getCreateTime());
+        vo.setUpdateBy(dept.getUpdateBy());
+        vo.setUpdateTime(dept.getUpdateTime());
+        return vo;
+    }
+
+    private SysDept requireActive(Long id) {
+        SysDept dept = deptMapper.selectById(id);
+        if (dept == null || (dept.getDelFlag() != null && dept.getDelFlag() == 1)) {
+            throw new IllegalArgumentException("部门不存在: " + id);
+        }
+        return dept;
+    }
+
+    private void ensureNameUnique(Long parentId, String name, Long excludeId) {
+        Long count = deptMapper.selectCount(
+                Wrappers.<SysDept>lambdaQuery()
+                        .eq(SysDept::getParentId, parentId)
+                        .eq(SysDept::getName, name)
+                        .eq(SysDept::getDelFlag, 0)
+                        .ne(excludeId != null, SysDept::getId, excludeId)
+        );
+        if (count != null && count > 0) {
+            throw new IllegalArgumentException("同一父级下部门名称已存在");
+        }
+    }
+
+    private Long normalizeParentId(Long parentId) {
+        return parentId == null ? 0L : parentId;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String buildPendingPath(Long parentId) {
+        long random = ThreadLocalRandom.current().nextLong(1_000_000_000L, 9_999_999_999L);
+        long pid = parentId == null ? 0L : parentId;
+        return "/" + pid + "/" + random + "/";
+    }
+
+    private String buildPath(SysDept parent, Long selfId) {
+        String prefix = parent == null ? "/" : parent.getPath();
+        if (prefix == null || prefix.isEmpty()) {
+            prefix = "/";
+        }
+        if (!prefix.endsWith("/")) {
+            prefix = prefix + "/";
+        }
+        return prefix + selfId + "/";
+    }
+
+    private void bumpTreeVersionAndEvict(Collection<Long> deptIds) {
+        try {
+            stringRedisTemplate.opsForValue().increment(IamCacheKeys.DEPT_TREE_VERSION);
+        } catch (Exception ignored) {
+        }
+        if (deptIds == null || deptIds.isEmpty()) {
+            return;
+        }
+        List<String> keys = deptIds.stream()
+                .filter(Objects::nonNull)
+                .map(id -> IamCacheKeys.DEPT_SCOPE + id)
+                .collect(Collectors.toList());
+        if (keys.isEmpty()) {
+            return;
+        }
+        try {
+            stringRedisTemplate.delete(keys);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysDeptMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysDeptMapper.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xrcgs.iam.mapper.SysDeptMapper">
+
+    <resultMap id="DeptMap" type="com.xrcgs.iam.entity.SysDept">
+        <id property="id" column="id"/>
+        <result property="parentId" column="parent_id"/>
+        <result property="path" column="path"/>
+        <result property="name" column="name"/>
+        <result property="code" column="code"/>
+        <result property="status" column="status"/>
+        <result property="sortNo" column="sort_no"/>
+        <result property="leaderUserId" column="leader_user_id"/>
+        <result property="phone" column="phone"/>
+        <result property="email" column="email"/>
+        <result property="remark" column="remark"/>
+        <result property="createBy" column="create_by"/>
+        <result property="createTime" column="create_time"/>
+        <result property="updateBy" column="update_by"/>
+        <result property="updateTime" column="update_time"/>
+        <result property="delFlag" column="del_flag"/>
+    </resultMap>
+
+    <sql id="BaseColumns">
+        id, parent_id, path, name, code, status, sort_no, leader_user_id,
+        phone, email, remark, create_by, create_time, update_by, update_time, del_flag
+    </sql>
+
+    <select id="selectChildren" resultMap="DeptMap">
+        SELECT
+        <include refid="BaseColumns"/>
+        FROM sys_dept
+        WHERE parent_id = #{parentId}
+          AND del_flag = 0
+        ORDER BY sort_no ASC, id ASC
+    </select>
+
+    <select id="selectByPathPrefix" resultMap="DeptMap">
+        SELECT
+        <include refid="BaseColumns"/>
+        FROM sys_dept
+        WHERE path LIKE CONCAT(#{pathPrefix}, '%')
+          AND del_flag = 0
+        ORDER BY path ASC
+    </select>
+
+    <select id="selectIdsByPathPrefix" resultType="java.lang.Long">
+        SELECT id
+        FROM sys_dept
+        WHERE path LIKE CONCAT(#{pathPrefix}, '%')
+          AND del_flag = 0
+    </select>
+
+    <update id="updatePathPrefix">
+        UPDATE sys_dept
+        SET path = CONCAT(#{newPath}, SUBSTRING(path, CHAR_LENGTH(#{oldPath}) + 1)),
+            update_time = NOW()
+        WHERE path LIKE CONCAT(#{oldPath}, '%')
+    </update>
+
+    <select id="countChildren" resultType="java.lang.Long">
+        SELECT COUNT(1)
+        FROM sys_dept
+        WHERE parent_id = #{parentId}
+          AND del_flag = 0
+    </select>
+
+</mapper>

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.xrcgs.iam.service.impl;
+
+import com.xrcgs.common.constants.IamCacheKeys;
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.mapper.SysDeptMapper;
+import com.xrcgs.iam.model.dto.DeptUpsertDTO;
+import com.xrcgs.iam.model.vo.DeptTreeVO;
+import com.xrcgs.iam.model.vo.DeptVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeptServiceImplTest {
+
+    @Mock
+    private SysDeptMapper deptMapper;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private DeptServiceImpl deptService;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(anyString())).thenReturn(1L);
+        when(redisTemplate.delete(any(Collection.class))).thenReturn(1L);
+        deptService = new DeptServiceImpl(deptMapper, redisTemplate);
+    }
+
+    @Test
+    void createShouldInsertAndUpdatePathAndBumpCache() {
+        DeptUpsertDTO dto = new DeptUpsertDTO();
+        dto.setParentId(1L);
+        dto.setName("研发中心");
+        dto.setSortNo(10);
+
+        SysDept parent = new SysDept();
+        parent.setId(1L);
+        parent.setPath("/1/");
+
+        when(deptMapper.selectById(1L)).thenReturn(parent);
+        when(deptMapper.selectCount(any())).thenReturn(0L);
+        doAnswer(invocation -> {
+            SysDept arg = invocation.getArgument(0);
+            arg.setId(10L);
+            return 1;
+        }).when(deptMapper).insert(any(SysDept.class));
+
+        Long id = deptService.create(dto);
+        assertEquals(10L, id);
+
+        ArgumentCaptor<SysDept> updateCaptor = ArgumentCaptor.forClass(SysDept.class);
+        verify(deptMapper).updateById(updateCaptor.capture());
+        SysDept updated = updateCaptor.getValue();
+        assertEquals("/1/10/", updated.getPath());
+        assertEquals("研发中心", updated.getName());
+        assertEquals(1L, updated.getParentId());
+
+        verify(valueOperations).increment(IamCacheKeys.DEPT_TREE_VERSION);
+        verify(redisTemplate).delete(argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "10")));
+    }
+
+    @Test
+    void updateShouldMoveDepartmentAndEvictCaches() {
+        DeptUpsertDTO dto = new DeptUpsertDTO();
+        dto.setParentId(3L);
+        dto.setName("新名称");
+        dto.setSortNo(20);
+
+        SysDept current = new SysDept();
+        current.setId(2L);
+        current.setParentId(1L);
+        current.setPath("/1/2/");
+        current.setStatus(1);
+        current.setSortNo(10);
+
+        SysDept newParent = new SysDept();
+        newParent.setId(3L);
+        newParent.setPath("/1/3/");
+
+        when(deptMapper.selectById(2L)).thenReturn(current);
+        when(deptMapper.selectById(3L)).thenReturn(newParent);
+        when(deptMapper.selectCount(any())).thenReturn(0L);
+        when(deptMapper.selectIdsByPathPrefix("/1/2/")).thenReturn(Arrays.asList(2L, 5L));
+
+        deptService.update(2L, dto);
+
+        verify(deptMapper).updatePathPrefix("/1/2/", "/1/3/2/");
+
+        ArgumentCaptor<SysDept> updateCaptor = ArgumentCaptor.forClass(SysDept.class);
+        verify(deptMapper).updateById(updateCaptor.capture());
+        SysDept updated = updateCaptor.getValue();
+        assertEquals("/1/3/2/", updated.getPath());
+        assertEquals(3L, updated.getParentId());
+        assertEquals("新名称", updated.getName());
+
+        verify(valueOperations, atLeastOnce()).increment(IamCacheKeys.DEPT_TREE_VERSION);
+        verify(redisTemplate).delete(argThat(keys ->
+                keys.contains(IamCacheKeys.DEPT_SCOPE + "2") &&
+                        keys.contains(IamCacheKeys.DEPT_SCOPE + "5")));
+    }
+
+    @Test
+    void updateShouldRejectCycle() {
+        SysDept current = new SysDept();
+        current.setId(2L);
+        current.setPath("/1/2/");
+
+        SysDept parent = new SysDept();
+        parent.setId(5L);
+        parent.setPath("/1/2/5/");
+
+        when(deptMapper.selectById(2L)).thenReturn(current);
+        when(deptMapper.selectById(5L)).thenReturn(parent);
+
+        DeptUpsertDTO dto = new DeptUpsertDTO();
+        dto.setParentId(5L);
+        dto.setName("测试");
+
+        assertThrows(IllegalArgumentException.class, () -> deptService.update(2L, dto));
+    }
+
+    @Test
+    void deleteShouldFailWhenChildrenExist() {
+        SysDept current = new SysDept();
+        current.setId(2L);
+        current.setPath("/1/2/");
+
+        when(deptMapper.selectById(2L)).thenReturn(current);
+        when(deptMapper.countChildren(2L)).thenReturn(1L);
+
+        assertThrows(IllegalStateException.class, () -> deptService.delete(2L));
+        verify(deptMapper, never()).deleteById(anyLong());
+    }
+
+    @Test
+    void deleteShouldEvictCaches() {
+        SysDept current = new SysDept();
+        current.setId(4L);
+        current.setPath("/1/4/");
+
+        when(deptMapper.selectById(4L)).thenReturn(current);
+        when(deptMapper.countChildren(4L)).thenReturn(0L);
+        when(deptMapper.selectIdsByPathPrefix("/1/4/")).thenReturn(Collections.singletonList(4L));
+
+        deptService.delete(4L);
+
+        verify(deptMapper).deleteById(4L);
+        verify(redisTemplate).delete(argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "4")));
+    }
+
+    @Test
+    void treeShouldBuildHierarchy() {
+        SysDept root = new SysDept();
+        root.setId(1L);
+        root.setParentId(0L);
+        root.setName("根");
+        root.setSortNo(1);
+
+        SysDept child = new SysDept();
+        child.setId(2L);
+        child.setParentId(1L);
+        child.setName("子");
+        child.setSortNo(2);
+
+        when(deptMapper.selectList(any())).thenReturn(Arrays.asList(root, child));
+
+        List<DeptTreeVO> tree = deptService.tree(null);
+        assertEquals(1, tree.size());
+        DeptTreeVO rootNode = tree.get(0);
+        assertEquals("根", rootNode.getName());
+        assertEquals(1, rootNode.getChildren().size());
+        assertEquals("子", rootNode.getChildren().get(0).getName());
+    }
+
+    @Test
+    void detailShouldReturnDeptVo() {
+        SysDept dept = new SysDept();
+        dept.setId(3L);
+        dept.setName("市场");
+
+        when(deptMapper.selectById(3L)).thenReturn(dept);
+
+        DeptVO vo = deptService.detail(3L);
+        assertEquals("市场", vo.getName());
+    }
+}


### PR DESCRIPTION
## Summary
- add SysDept entity with DTO/VO companions plus mapper utilities for child and path lookups
- implement DeptService with validation, path recomputation and Redis cache version/scope eviction, and wire new controller endpoints
- cover new behaviours with unit tests around create/update/delete flows

## Testing
- mvn -pl xrcgs-module-iam test *(fails: unable to download Spring Boot BOM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc9159c08321af9da6b9075dc0d0