### PR TITLE
Fix Redis delete matcher generics in DeptServiceImplTest

### DIFF
--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -42,7 +43,7 @@ class DeptServiceImplTest {
     void setUp() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.increment(anyString())).thenReturn(1L);
-        when(redisTemplate.delete(any(Collection.class))).thenReturn(1L);
+        when(redisTemplate.delete(ArgumentMatchers.<Collection<String>>any())).thenReturn(1L);
         deptService = new DeptServiceImpl(deptMapper, redisTemplate);
     }
 
@@ -76,7 +77,7 @@ class DeptServiceImplTest {
         assertEquals(1L, updated.getParentId());
 
         verify(valueOperations).increment(IamCacheKeys.DEPT_TREE_VERSION);
-        verify(redisTemplate).delete(argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "10")));
+        verify(redisTemplate).delete(ArgumentMatchers.<Collection<String>>argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "10")));
     }
 
     @Test
@@ -114,7 +115,7 @@ class DeptServiceImplTest {
         assertEquals("新名称", updated.getName());
 
         verify(valueOperations, atLeastOnce()).increment(IamCacheKeys.DEPT_TREE_VERSION);
-        verify(redisTemplate).delete(argThat(keys ->
+        verify(redisTemplate).delete(ArgumentMatchers.<Collection<String>>argThat(keys ->
                 keys.contains(IamCacheKeys.DEPT_SCOPE + "2") &&
                         keys.contains(IamCacheKeys.DEPT_SCOPE + "5")));
     }
@@ -165,7 +166,7 @@ class DeptServiceImplTest {
         deptService.delete(4L);
 
         verify(deptMapper).deleteById(4L);
-        verify(redisTemplate).delete(argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "4")));
+        verify(redisTemplate).delete(ArgumentMatchers.<Collection<String>>argThat(keys -> keys.contains(IamCacheKeys.DEPT_SCOPE + "4")));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add an explicit ArgumentMatchers import to reference typed matchers
- constrain redisTemplate.delete() stubbing and verifications to the Collection<String> overload

## Testing
- `mvn -pl xrcgs-module-iam -am -Dtest=DeptServiceImplTest test` *(fails: unable to reach repo.maven.apache.org from container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdff622b8832187fb72df7d6ea1ea