### PR TITLE
Add data scope computation and caching

### DIFF
--- a/xrcgs-common/src/main/java/com/xrcgs/common/cache/AuthCacheService.java
+++ b/xrcgs-common/src/main/java/com/xrcgs/common/cache/AuthCacheService.java
@@ -1,11 +1,17 @@
 package com.xrcgs.common.cache;
 
+import com.xrcgs.iam.datascope.EffectiveDataScope;
+
 import java.util.Set;
 
 public interface AuthCacheService {
     void cacheUserPerms(Long userId, Set<String> perms);
     Set<String> getCachedUserPerms(Long userId);
     void evictUserPerms(Long userId);
+
+    void cacheUserDataScope(Long userId, EffectiveDataScope scope);
+    EffectiveDataScope getCachedUserDataScope(Long userId);
+    void evictUserDataScope(Long userId);
 
     void cacheMenuTreeByRole(Long roleId, String json);
     String getCachedMenuTreeByRole(Long roleId);

--- a/xrcgs-common/src/main/java/com/xrcgs/common/constants/IamCacheKeys.java
+++ b/xrcgs-common/src/main/java/com/xrcgs/common/constants/IamCacheKeys.java
@@ -7,6 +7,7 @@ public interface IamCacheKeys {
 
     // 用户权限集合（含角色、权限码、通配符），7-4 会在登录时写入/读取
     String AUTH_PERM_USER = "auth:perm:"; // + {userId}
+    String AUTH_SCOPE_USER = "auth:scope:"; // + {userId}
 
     // 菜单树缓存（可按角色维度缓存）
     String MENU_TREE_ROLE = "menu:tree:"; // + {roleId} or "ALL"

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeCalculator.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeCalculator.java
@@ -1,0 +1,107 @@
+package com.xrcgs.iam.datascope;
+
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.entity.SysRole;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.enums.DataScope;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Combine user/role configuration into a single {@link EffectiveDataScope} instance.
+ */
+@Component
+public class DataScopeCalculator {
+
+    public EffectiveDataScope calculate(SysUser user, List<SysRole> roles, List<SysDept> departments) {
+        if (user == null) {
+            return EffectiveDataScope.selfOnly();
+        }
+        Map<Long, Set<Long>> children = DataScopeUtil.buildChildrenMap(departments);
+
+        boolean all = false;
+        boolean self = false;
+        Set<Long> deptIds = new LinkedHashSet<>();
+
+        DataScope userScope = user.getDataScope() == null ? DataScope.SELF : user.getDataScope();
+        Set<Long> userExtraDepts = DataScopeUtil.parseIdSet(user.getExtraDeptIds());
+        Set<Long> userCustomDepts = DataScopeUtil.parseIdSet(user.getDataScopeExt());
+
+        switch (userScope) {
+            case ALL -> all = true;
+            case SELF -> self = true;
+            case DEPT -> {
+                addDept(user.getDeptId(), deptIds);
+                DataScopeUtil.merge(deptIds, userExtraDepts);
+            }
+            case DEPT_AND_CHILD -> {
+                deptIds.addAll(DataScopeUtil.collectWithChildren(user.getDeptId(), children));
+                for (Long extra : userExtraDepts) {
+                    deptIds.addAll(DataScopeUtil.collectWithChildren(extra, children));
+                }
+            }
+            case CUSTOM -> DataScopeUtil.merge(deptIds, userCustomDepts);
+        }
+
+        if (!all && roles != null) {
+            for (SysRole role : roles) {
+                if (role == null) {
+                    continue;
+                }
+                if (role.getDelFlag() != null && role.getDelFlag() == 1) {
+                    continue;
+                }
+                if (role.getStatus() != null && role.getStatus() != 1) {
+                    continue;
+                }
+                DataScope scope = role.getDataScope() == null ? DataScope.SELF : role.getDataScope();
+                Set<Long> extraDepts = DataScopeUtil.parseIdSet(role.getExtraDeptIds());
+                Set<Long> customDepts = DataScopeUtil.parseIdSet(role.getDataScopeExt());
+                switch (scope) {
+                    case ALL -> {
+                        all = true;
+                        self = true;
+                    }
+                    case SELF -> self = true;
+                    case DEPT -> {
+                        Long base = role.getDeptId() != null ? role.getDeptId() : user.getDeptId();
+                        addDept(base, deptIds);
+                        DataScopeUtil.merge(deptIds, extraDepts);
+                    }
+                    case DEPT_AND_CHILD -> {
+                        Long base = role.getDeptId() != null ? role.getDeptId() : user.getDeptId();
+                        deptIds.addAll(DataScopeUtil.collectWithChildren(base, children));
+                        for (Long extra : extraDepts) {
+                            deptIds.addAll(DataScopeUtil.collectWithChildren(extra, children));
+                        }
+                    }
+                    case CUSTOM -> DataScopeUtil.merge(deptIds, customDepts);
+                }
+                if (all) {
+                    break;
+                }
+            }
+        }
+
+        if (all) {
+            return EffectiveDataScope.all();
+        }
+
+        if (!self && deptIds.isEmpty()) {
+            self = true;
+        }
+
+        return EffectiveDataScope.ofDepartments(deptIds, self);
+    }
+
+    private void addDept(Long deptId, Collection<Long> target) {
+        if (deptId != null && target != null) {
+            target.add(deptId);
+        }
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeContext.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeContext.java
@@ -1,0 +1,44 @@
+package com.xrcgs.iam.datascope;
+
+import java.util.function.Supplier;
+
+/**
+ * Simple holder to expose the effective data scope for the duration of a request.
+ */
+public final class DataScopeContext {
+
+    private static final ThreadLocal<EffectiveDataScope> CONTEXT = new ThreadLocal<>();
+
+    private DataScopeContext() {
+    }
+
+    public static EffectiveDataScope get() {
+        return CONTEXT.get();
+    }
+
+    public static void set(EffectiveDataScope scope) {
+        if (scope == null) {
+            CONTEXT.remove();
+        } else {
+            CONTEXT.set(scope);
+        }
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+
+    public static <T> T withScope(EffectiveDataScope scope, Supplier<T> supplier) {
+        EffectiveDataScope previous = CONTEXT.get();
+        CONTEXT.set(scope);
+        try {
+            return supplier.get();
+        } finally {
+            if (previous == null) {
+                CONTEXT.remove();
+            } else {
+                CONTEXT.set(previous);
+            }
+        }
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeManager.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeManager.java
@@ -1,0 +1,121 @@
+package com.xrcgs.iam.datascope;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.xrcgs.common.cache.AuthCacheService;
+import com.xrcgs.common.constants.IamCacheKeys;
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.entity.SysRole;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.entity.SysUserRole;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class DataScopeManager {
+
+    private final AuthCacheService authCacheService;
+    private final DataScopeCalculator calculator;
+    private final com.xrcgs.iam.mapper.SysUserMapper userMapper;
+    private final com.xrcgs.iam.mapper.SysUserRoleMapper userRoleMapper;
+    private final com.xrcgs.iam.mapper.SysRoleMapper roleMapper;
+    private final com.xrcgs.iam.mapper.SysDeptMapper deptMapper;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public DataScopeManager(AuthCacheService authCacheService,
+                            DataScopeCalculator calculator,
+                            com.xrcgs.iam.mapper.SysUserMapper userMapper,
+                            com.xrcgs.iam.mapper.SysUserRoleMapper userRoleMapper,
+                            com.xrcgs.iam.mapper.SysRoleMapper roleMapper,
+                            com.xrcgs.iam.mapper.SysDeptMapper deptMapper,
+                            StringRedisTemplate stringRedisTemplate) {
+        this.authCacheService = authCacheService;
+        this.calculator = calculator;
+        this.userMapper = userMapper;
+        this.userRoleMapper = userRoleMapper;
+        this.roleMapper = roleMapper;
+        this.deptMapper = deptMapper;
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public EffectiveDataScope getEffectiveDataScope(Long userId) {
+        if (userId == null) {
+            return EffectiveDataScope.selfOnly();
+        }
+        long currentVersion = currentDeptTreeVersion();
+        EffectiveDataScope cached = authCacheService.getCachedUserDataScope(userId);
+        if (cached != null) {
+            long cachedVersion = DataScopeUtil.nullSafeVersion(cached.getDeptTreeVersion());
+            if (cachedVersion == currentVersion) {
+                return cached;
+            }
+        }
+        EffectiveDataScope computed = compute(userId);
+        computed.setDeptTreeVersion(currentVersion);
+        authCacheService.cacheUserDataScope(userId, computed);
+        return computed;
+    }
+
+    public void evictUserDataScope(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        authCacheService.evictUserDataScope(userId);
+    }
+
+    private EffectiveDataScope compute(Long userId) {
+        SysUser user = userMapper.selectById(userId);
+        if (user == null) {
+            return EffectiveDataScope.selfOnly();
+        }
+        List<SysUserRole> relations = userRoleMapper.selectList(
+                Wrappers.<SysUserRole>lambdaQuery().eq(SysUserRole::getUserId, userId)
+        );
+        Set<Long> roleIds = relations.stream()
+                .map(SysUserRole::getRoleId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        List<SysRole> roles;
+        if (roleIds.isEmpty()) {
+            roles = Collections.emptyList();
+        } else {
+            roles = roleMapper.selectBatchIds(roleIds);
+        }
+        if (roles != null) {
+            roles = roles.stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        } else {
+            roles = Collections.emptyList();
+        }
+        List<SysDept> depts = deptMapper.selectList(
+                Wrappers.<SysDept>lambdaQuery().eq(SysDept::getDelFlag, 0)
+        );
+        if (depts == null) {
+            depts = Collections.emptyList();
+        }
+        return calculator.calculate(user, roles, depts);
+    }
+
+    private long currentDeptTreeVersion() {
+        try {
+            ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+            if (ops == null) {
+                return 0L;
+            }
+            String value = ops.get(IamCacheKeys.DEPT_TREE_VERSION);
+            if (value == null || value.isBlank()) {
+                return 0L;
+            }
+            return Long.parseLong(value.trim());
+        } catch (Exception ignored) {
+            return 0L;
+        }
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeUtil.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/DataScopeUtil.java
@@ -1,0 +1,127 @@
+package com.xrcgs.iam.datascope;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xrcgs.iam.entity.SysDept;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helper methods used by the data scope calculation pipeline.
+ */
+public final class DataScopeUtil {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private DataScopeUtil() {
+    }
+
+    public static Set<Long> parseIdSet(String jsonArray) {
+        if (jsonArray == null || jsonArray.isBlank()) {
+            return Collections.emptySet();
+        }
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(jsonArray);
+            if (node == null || !node.isArray()) {
+                return Collections.emptySet();
+            }
+            Set<Long> ids = new LinkedHashSet<>();
+            for (JsonNode element : node) {
+                Long value = toLong(element);
+                if (value != null) {
+                    ids.add(value);
+                }
+            }
+            return ids;
+        } catch (Exception ignored) {
+            return Collections.emptySet();
+        }
+    }
+
+    private static Long toLong(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        if (node.isIntegralNumber()) {
+            return node.longValue();
+        }
+        if (node.isTextual()) {
+            String text = node.asText();
+            if (text != null) {
+                text = text.trim();
+                if (!text.isEmpty()) {
+                    try {
+                        return Long.parseLong(text);
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public static Map<Long, Set<Long>> buildChildrenMap(List<SysDept> departments) {
+        Map<Long, Set<Long>> children = new HashMap<>();
+        if (departments == null) {
+            return children;
+        }
+        for (SysDept dept : departments) {
+            if (dept == null || dept.getId() == null) {
+                continue;
+            }
+            Long parentId = dept.getParentId();
+            if (parentId == null) {
+                parentId = 0L;
+            }
+            children.computeIfAbsent(parentId, k -> new LinkedHashSet<>()).add(dept.getId());
+        }
+        return children;
+    }
+
+    public static Set<Long> collectWithChildren(Long deptId, Map<Long, Set<Long>> childrenMap) {
+        if (deptId == null) {
+            return Collections.emptySet();
+        }
+        Set<Long> result = new LinkedHashSet<>();
+        Deque<Long> queue = new ArrayDeque<>();
+        queue.add(deptId);
+        while (!queue.isEmpty()) {
+            Long current = queue.poll();
+            if (current == null || !result.add(current)) {
+                continue;
+            }
+            Set<Long> children = childrenMap.get(current);
+            if (children != null) {
+                for (Long child : children) {
+                    if (child != null) {
+                        queue.add(child);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public static void merge(Set<Long> target, Collection<Long> source) {
+        if (target == null || source == null) {
+            return;
+        }
+        for (Long id : source) {
+            if (id != null) {
+                target.add(id);
+            }
+        }
+    }
+
+    public static long nullSafeVersion(Long version) {
+        return version == null ? 0L : version;
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/EffectiveDataScope.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/datascope/EffectiveDataScope.java
@@ -1,0 +1,120 @@
+package com.xrcgs.iam.datascope;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Result object describing the effective data scope of a user after
+ * combining role/user level rules.
+ */
+public class EffectiveDataScope {
+
+    private boolean all;
+    private boolean self;
+    private Set<Long> deptIds = new LinkedHashSet<>();
+    private Long deptTreeVersion;
+
+    public EffectiveDataScope() {
+    }
+
+    private EffectiveDataScope(boolean all, boolean self, Collection<Long> deptIds) {
+        this.all = all;
+        this.self = self;
+        setDeptIds(deptIds);
+    }
+
+    public static EffectiveDataScope all() {
+        EffectiveDataScope scope = new EffectiveDataScope(true, true, Collections.emptySet());
+        scope.deptTreeVersion = 0L;
+        return scope;
+    }
+
+    public static EffectiveDataScope selfOnly() {
+        EffectiveDataScope scope = new EffectiveDataScope(false, true, Collections.emptySet());
+        scope.deptTreeVersion = 0L;
+        return scope;
+    }
+
+    public static EffectiveDataScope ofDepartments(Collection<Long> deptIds, boolean includeSelf) {
+        return new EffectiveDataScope(false, includeSelf, deptIds);
+    }
+
+    public boolean isAll() {
+        return all;
+    }
+
+    public void setAll(boolean all) {
+        this.all = all;
+    }
+
+    public boolean isSelf() {
+        return self;
+    }
+
+    public void setSelf(boolean self) {
+        this.self = self;
+    }
+
+    public Set<Long> getDeptIds() {
+        return Collections.unmodifiableSet(deptIds);
+    }
+
+    public void setDeptIds(Collection<Long> deptIds) {
+        this.deptIds.clear();
+        if (deptIds == null) {
+            return;
+        }
+        for (Long id : deptIds) {
+            if (id != null) {
+                this.deptIds.add(id);
+            }
+        }
+    }
+
+    @JsonIgnore
+    public boolean hasDepartments() {
+        return !deptIds.isEmpty();
+    }
+
+    public Long getDeptTreeVersion() {
+        return deptTreeVersion;
+    }
+
+    public void setDeptTreeVersion(Long deptTreeVersion) {
+        this.deptTreeVersion = deptTreeVersion;
+    }
+
+    public EffectiveDataScope copy() {
+        EffectiveDataScope scope = new EffectiveDataScope(all, self, deptIds);
+        scope.setDeptTreeVersion(deptTreeVersion);
+        return scope;
+    }
+
+    @Override
+    public String toString() {
+        return "EffectiveDataScope{" +
+                "all=" + all +
+                ", self=" + self +
+                ", deptIds=" + deptIds +
+                ", deptTreeVersion=" + deptTreeVersion +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EffectiveDataScope that)) return false;
+        return all == that.all && self == that.self && Objects.equals(deptIds, that.deptIds)
+                && Objects.equals(deptTreeVersion, that.deptTreeVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(all, self, deptIds, deptTreeVersion);
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysRole.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysRole.java
@@ -18,10 +18,16 @@ public class SysRole {
     private String name;
     private Integer status;
 
+    private Long deptId;
+
+    @TableField("extra_dept_ids")
+    private String extraDeptIds;
+
     @TableField("data_scope")
     private DataScope dataScope;
 
     /** CUSTOM 时存部门ID数组 JSON（如 [1,2,3]） */
+    @TableField("data_scope_ext")
     private String dataScopeExt;
 
     private String remark;

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysUser.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysUser.java
@@ -1,8 +1,10 @@
 package com.xrcgs.iam.entity;
 
 import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
+import com.xrcgs.iam.enums.DataScope;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -18,6 +20,17 @@ public class SysUser {
     private String password;
     private String nickname;
     private Boolean enabled;
+
+    private Long deptId;
+
+    @TableField("extra_dept_ids")
+    private String extraDeptIds;
+
+    @TableField("data_scope")
+    private DataScope dataScope;
+
+    @TableField("data_scope_ext")
+    private String dataScopeExt;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermServiceImpl.java
@@ -1,6 +1,7 @@
 package com.xrcgs.iam.service.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.xrcgs.iam.datascope.DataScopeManager;
 import com.xrcgs.iam.entity.SysMenu;
 import com.xrcgs.iam.entity.SysPermission;
 import com.xrcgs.iam.entity.SysRolePerm;
@@ -26,6 +27,7 @@ public class PermServiceImpl implements PermService {
     private final SysRolePermMapper rolePermMapper;
     private final SysPermissionMapper permissionMapper;
     private final AuthCacheService cache;
+    private final DataScopeManager dataScopeManager;
 
     @Override
     public Set<String> aggregatePermsByRoles(Set<Long> roleIds) {
@@ -82,5 +84,6 @@ public class PermServiceImpl implements PermService {
     @Override
     public void evictUserPerms(Long userId) {
         cache.evictUserPerms(userId);
+        dataScopeManager.evictUserDataScope(userId);
     }
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/RoleServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/RoleServiceImpl.java
@@ -3,6 +3,7 @@ package com.xrcgs.iam.service.impl;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xrcgs.iam.datascope.DataScopeManager;
 import com.xrcgs.iam.entity.*;
 import com.xrcgs.iam.mapper.*;
 import com.xrcgs.iam.model.dto.RoleGrantMenuDTO;
@@ -26,6 +27,7 @@ public class RoleServiceImpl implements RoleService {
     private final SysRolePermMapper rolePermMapper;
     private final SysUserRoleMapper userRoleMapper;
     private final AuthCacheService authCacheService;
+    private final DataScopeManager dataScopeManager;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -138,6 +140,7 @@ public class RoleServiceImpl implements RoleService {
                 Wrappers.<SysUserRole>lambdaQuery().eq(SysUserRole::getRoleId, roleId));
         for (SysUserRole ur : urs) {
             authCacheService.evictUserPerms(ur.getUserId());
+            dataScopeManager.evictUserDataScope(ur.getUserId());
         }
     }
 }

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeCalculatorTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeCalculatorTest.java
@@ -1,0 +1,82 @@
+package com.xrcgs.iam.datascope;
+
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.entity.SysRole;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.enums.DataScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataScopeCalculatorTest {
+
+    private final DataScopeCalculator calculator = new DataScopeCalculator();
+
+    @Test
+    void shouldAggregateUserAndRoleScopes() {
+        SysUser user = new SysUser();
+        user.setDeptId(1L);
+        user.setExtraDeptIds("[4]");
+        user.setDataScope(DataScope.DEPT_AND_CHILD);
+
+        SysRole customRole = new SysRole();
+        customRole.setStatus(1);
+        customRole.setDelFlag(0);
+        customRole.setDataScope(DataScope.CUSTOM);
+        customRole.setDataScopeExt("[3]");
+
+        SysRole deptRole = new SysRole();
+        deptRole.setStatus(1);
+        deptRole.setDelFlag(0);
+        deptRole.setDataScope(DataScope.DEPT);
+        deptRole.setDeptId(2L);
+        deptRole.setExtraDeptIds("[5]");
+
+        SysRole selfRole = new SysRole();
+        selfRole.setStatus(1);
+        selfRole.setDelFlag(0);
+        selfRole.setDataScope(DataScope.SELF);
+
+        List<SysDept> departments = new ArrayList<>();
+        departments.add(dept(1L, 0L));
+        departments.add(dept(2L, 1L));
+        departments.add(dept(3L, 1L));
+        departments.add(dept(4L, 2L));
+        departments.add(dept(5L, 4L));
+
+        EffectiveDataScope scope = calculator.calculate(user, List.of(customRole, deptRole, selfRole), departments);
+
+        assertFalse(scope.isAll());
+        assertTrue(scope.isSelf());
+        assertTrue(scope.getDeptIds().containsAll(Set.of(1L, 2L, 3L, 4L, 5L)));
+    }
+
+    @Test
+    void shouldReturnAllWhenAnyScopeIsAll() {
+        SysUser user = new SysUser();
+        user.setDataScope(DataScope.SELF);
+
+        SysRole allRole = new SysRole();
+        allRole.setStatus(1);
+        allRole.setDelFlag(0);
+        allRole.setDataScope(DataScope.ALL);
+
+        EffectiveDataScope scope = calculator.calculate(user, List.of(allRole), List.of());
+
+        assertTrue(scope.isAll());
+        assertTrue(scope.isSelf());
+        assertTrue(scope.getDeptIds().isEmpty());
+    }
+
+    private SysDept dept(Long id, Long parentId) {
+        SysDept dept = new SysDept();
+        dept.setId(id);
+        dept.setParentId(parentId);
+        dept.setDelFlag(0);
+        return dept;
+    }
+}

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeManagerTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeManagerTest.java
@@ -1,0 +1,111 @@
+package com.xrcgs.iam.datascope;
+
+import com.xrcgs.common.cache.AuthCacheService;
+import com.xrcgs.common.constants.IamCacheKeys;
+import com.xrcgs.iam.entity.SysDept;
+import com.xrcgs.iam.entity.SysRole;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.entity.SysUserRole;
+import com.xrcgs.iam.enums.DataScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DataScopeManagerTest {
+
+    @Mock
+    private AuthCacheService authCacheService;
+    @Mock
+    private com.xrcgs.iam.mapper.SysUserMapper userMapper;
+    @Mock
+    private com.xrcgs.iam.mapper.SysUserRoleMapper userRoleMapper;
+    @Mock
+    private com.xrcgs.iam.mapper.SysRoleMapper roleMapper;
+    @Mock
+    private com.xrcgs.iam.mapper.SysDeptMapper deptMapper;
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private DataScopeManager manager;
+
+    @BeforeEach
+    void setUp() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        manager = new DataScopeManager(authCacheService, new DataScopeCalculator(),
+                userMapper, userRoleMapper, roleMapper, deptMapper, stringRedisTemplate);
+    }
+
+    @Test
+    void shouldReturnCachedScopeWhenVersionMatches() {
+        when(valueOperations.get(IamCacheKeys.DEPT_TREE_VERSION)).thenReturn("5");
+        EffectiveDataScope cached = EffectiveDataScope.ofDepartments(Set.of(10L), true);
+        cached.setDeptTreeVersion(5L);
+        when(authCacheService.getCachedUserDataScope(1L)).thenReturn(cached);
+
+        EffectiveDataScope result = manager.getEffectiveDataScope(1L);
+
+        assertSame(cached, result);
+        verifyNoInteractions(userMapper, userRoleMapper, roleMapper, deptMapper);
+        verify(authCacheService, never()).cacheUserDataScope(anyLong(), any());
+    }
+
+    @Test
+    void shouldRecalculateWhenVersionMismatch() {
+        when(valueOperations.get(IamCacheKeys.DEPT_TREE_VERSION)).thenReturn("7");
+        EffectiveDataScope cached = EffectiveDataScope.selfOnly();
+        cached.setDeptTreeVersion(2L);
+        when(authCacheService.getCachedUserDataScope(1L)).thenReturn(cached);
+
+        SysUser user = new SysUser();
+        user.setId(1L);
+        user.setDeptId(10L);
+        user.setDataScope(DataScope.DEPT);
+        when(userMapper.selectById(1L)).thenReturn(user);
+
+        SysUserRole relation = new SysUserRole();
+        relation.setRoleId(100L);
+        when(userRoleMapper.selectList(any())).thenReturn(List.of(relation));
+
+        SysRole role = new SysRole();
+        role.setId(100L);
+        role.setStatus(1);
+        role.setDelFlag(0);
+        role.setDataScope(DataScope.CUSTOM);
+        role.setDataScopeExt("[11]");
+        when(roleMapper.selectBatchIds(anyCollection())).thenReturn(List.of(role));
+
+        SysDept dept10 = new SysDept();
+        dept10.setId(10L);
+        dept10.setParentId(0L);
+        dept10.setDelFlag(0);
+        SysDept dept11 = new SysDept();
+        dept11.setId(11L);
+        dept11.setParentId(10L);
+        dept11.setDelFlag(0);
+        when(deptMapper.selectList(any())).thenReturn(List.of(dept10, dept11));
+
+        EffectiveDataScope result = manager.getEffectiveDataScope(1L);
+
+        assertFalse(result.isAll());
+        assertTrue(result.getDeptIds().contains(11L));
+        assertEquals(7L, DataScopeUtil.nullSafeVersion(result.getDeptTreeVersion()));
+
+        verify(authCacheService).cacheUserDataScope(eq(1L), argThat(scope ->
+                scope.getDeptIds().contains(11L)
+                        && DataScopeUtil.nullSafeVersion(scope.getDeptTreeVersion()) == 7L));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a datascope package with `EffectiveDataScope`, calculator, manager, context and utilities to build version-aware scopes
- extend the auth cache API/implementation plus SysUser/SysRole and IAM services to cache and invalidate effective scopes alongside permissions
- add unit tests that cover mixed-role calculations and manager behaviour on cache version mismatches

## Testing
- mvn -pl xrcgs-module-iam -am test *(fails: unable to reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cce1aa78c48321ad26c528565e071c