### PR TITLE
Apply data scope filtering to file queries

### DIFF
--- a/xrcgs-module-file/pom.xml
+++ b/xrcgs-module-file/pom.xml
@@ -87,5 +87,11 @@
             <artifactId>xrcgs-module-syslog</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-module-iam</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/xrcgs-module-file/src/main/java/com/xrcgs/file/model/entity/SysFile.java
+++ b/xrcgs-module-file/src/main/java/com/xrcgs/file/model/entity/SysFile.java
@@ -31,6 +31,8 @@ public class SysFile {
     private String status;      // FileStatus 枚举名
     private String errorMsg;
 
+    private Long deptId;
+
     @TableField(fill = FieldFill.INSERT)
     private LocalDateTime createdAt;
 

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeUtilApplyTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/datascope/DataScopeUtilApplyTest.java
@@ -1,0 +1,98 @@
+package com.xrcgs.iam.datascope;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataScopeUtilApplyTest {
+
+    private static final class DummyEntity {
+        private Long createdBy;
+        private Long deptId;
+
+        public Long getCreatedBy() {
+            return createdBy;
+        }
+
+        public void setCreatedBy(Long createdBy) {
+            this.createdBy = createdBy;
+        }
+
+        public Long getDeptId() {
+            return deptId;
+        }
+
+        public void setDeptId(Long deptId) {
+            this.deptId = deptId;
+        }
+    }
+
+    @Test
+    void applyAllScopeLeavesWrapperUntouched() {
+        LambdaQueryWrapper<DummyEntity> wrapper = new LambdaQueryWrapper<>();
+        DataScopeUtil.apply(wrapper, EffectiveDataScope.all(), 1L, DummyEntity::getCreatedBy, DummyEntity::getDeptId);
+        String sql = wrapper.getSqlSegment();
+        assertTrue(sql == null || sql.isBlank(), "All scope should not add filters, but was: " + sql);
+        assertTrue(wrapper.getParamNameValuePairs().isEmpty());
+    }
+
+    @Test
+    void applySelfOnlyAddsCreatorPredicate() {
+        LambdaQueryWrapper<DummyEntity> wrapper = new LambdaQueryWrapper<>();
+        EffectiveDataScope scope = EffectiveDataScope.selfOnly();
+        DataScopeUtil.apply(wrapper, scope, 42L, DummyEntity::getCreatedBy, DummyEntity::getDeptId);
+        String sql = wrapper.getSqlSegment();
+        assertTrue(sql.contains("created_by"));
+        assertFalse(sql.contains("dept_id"));
+        assertEquals(1, wrapper.getParamNameValuePairs().size());
+        assertTrue(wrapper.getParamNameValuePairs().values().contains(42L));
+    }
+
+    @Test
+    void applyDeptOnlyAddsInFilter() {
+        LambdaQueryWrapper<DummyEntity> wrapper = new LambdaQueryWrapper<>();
+        EffectiveDataScope scope = EffectiveDataScope.ofDepartments(Set.of(10L, 11L), false);
+        DataScopeUtil.apply(wrapper, scope, 99L, DummyEntity::getCreatedBy, DummyEntity::getDeptId);
+        String sql = wrapper.getSqlSegment();
+        assertFalse(sql.contains("created_by"));
+        assertTrue(sql.contains("dept_id"));
+        assertFalse(wrapper.getParamNameValuePairs().isEmpty());
+        assertTrue(wrapper.getParamNameValuePairs().values().stream()
+                .filter(v -> v instanceof Iterable<?>)
+                .map(Iterable.class::cast)
+                .flatMap(iterable -> {
+                    java.util.List<Object> list = new java.util.ArrayList<>();
+                    iterable.forEach(list::add);
+                    return list.stream();
+                })
+                .anyMatch(v -> v.equals(10L) || v.equals(11L)));
+    }
+
+    @Test
+    void applySelfOrDeptWrapsWithOrCondition() {
+        LambdaQueryWrapper<DummyEntity> wrapper = new LambdaQueryWrapper<>();
+        EffectiveDataScope scope = EffectiveDataScope.ofDepartments(Set.of(5L), true);
+        DataScopeUtil.apply(wrapper, scope, 123L, DummyEntity::getCreatedBy, DummyEntity::getDeptId);
+        String sql = wrapper.getSqlSegment();
+        assertTrue(sql.contains("created_by"));
+        assertTrue(sql.contains("dept_id"));
+        assertTrue(sql.contains("OR"));
+    }
+
+    @Test
+    void applyQueryWrapperVariantBuildsClause() {
+        QueryWrapper<DummyEntity> wrapper = new QueryWrapper<>();
+        EffectiveDataScope scope = EffectiveDataScope.ofDepartments(Collections.emptySet(), false);
+        DataScopeUtil.apply(wrapper, scope, 9L, "created_by", "dept_id");
+        String sql = wrapper.getSqlSegment();
+        assertTrue(sql.contains("1 = 0"));
+        assertTrue(wrapper.getParamNameValuePairs().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add an apply helper to DataScopeUtil for composing creator and department predicates from an EffectiveDataScope
- expose sys_file.dept_id and update SysFileServiceImpl to resolve the current user's scope via DataScopeManager before querying
- depend on the IAM module from the file module and add tests covering self, department, and combined scope filters

## Testing
- mvn -pl xrcgs-module-iam,xrcgs-module-file -am test *(fails: unable to reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cd465330dc8321aaae3733aa35ef9b