### PR TITLE
Configure Jackson to format Java time types as strings

### DIFF
--- a/xrcgs-boot/src/main/java/com/xrcgs/boot/config/JacksonConfig.java
+++ b/xrcgs-boot/src/main/java/com/xrcgs/boot/config/JacksonConfig.java
@@ -1,0 +1,48 @@
+package com.xrcgs.boot.config;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilderCustomizer;
+
+/**
+ * Configures Jackson serialization/deserialization for Java time classes.
+ */
+@Configuration
+public class JacksonConfig {
+
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    private static final String DATE_PATTERN = "yyyy-MM-dd";
+    private static final String TIME_PATTERN = "HH:mm:ss";
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+        return builder -> {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
+            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN);
+
+            JavaTimeModule javaTimeModule = new JavaTimeModule();
+            javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));
+            javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(dateTimeFormatter));
+            javaTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer(dateFormatter));
+            javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(dateFormatter));
+            javaTimeModule.addSerializer(LocalTime.class, new LocalTimeSerializer(timeFormatter));
+            javaTimeModule.addDeserializer(LocalTime.class, new LocalTimeDeserializer(timeFormatter));
+
+            builder.modules(javaTimeModule);
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a Jackson configuration class that registers a JavaTimeModule with formatted LocalDateTime/LocalDate/LocalTime serializers and deserializers
- disable timestamp-based date serialization so API responses render formatted date-time strings

## Testing
- mvn -pl xrcgs-boot -am test *(fails: unable to reach repo.maven.apache.org to download Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd941a76b883218eb81539b3ad12ae