### PR TITLE
feat(iam): add user management service and API

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
@@ -1,0 +1,81 @@
+package com.xrcgs.iam.controller;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.xrcgs.common.core.R;
+import com.xrcgs.iam.model.dto.UserUpsertDTO;
+import com.xrcgs.iam.model.query.UserPageQuery;
+import com.xrcgs.iam.model.vo.UserVO;
+import com.xrcgs.iam.service.UserService;
+import com.xrcgs.syslog.annotation.OpLog;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequestMapping("/api/iam/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/page")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:list')")
+    public R<Page<UserVO>> page(@Valid UserPageQuery query,
+                                @RequestParam(defaultValue = "1") long pageNo,
+                                @RequestParam(defaultValue = "10") long pageSize) {
+        return R.ok(userService.page(query, pageNo, pageSize));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:list')")
+    public R<UserVO> detail(@PathVariable @NotNull Long id) {
+        return R.ok(userService.detail(id));
+    }
+
+    @PostMapping
+    @OpLog("新增用户")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:create')")
+    public R<Long> create(@Valid @RequestBody UserUpsertDTO dto) {
+        dto.setId(null);
+        return R.ok(userService.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    @OpLog("修改用户")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:update')")
+    public R<Boolean> update(@PathVariable @NotNull Long id,
+                             @Valid @RequestBody UserUpsertDTO dto) {
+        dto.setId(id);
+        userService.update(id, dto);
+        return R.ok(true);
+    }
+
+    @DeleteMapping("/{id}")
+    @OpLog("删除用户")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:delete')")
+    public R<Boolean> delete(@PathVariable @NotNull Long id) {
+        userService.delete(id);
+        return R.ok(true);
+    }
+
+    @PutMapping("/{id}/enable")
+    @OpLog("启用用户")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:enable')")
+    public R<Boolean> enable(@PathVariable @NotNull Long id) {
+        userService.updateEnabled(id, true);
+        return R.ok(true);
+    }
+
+    @PutMapping("/{id}/disable")
+    @OpLog("停用用户")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:disable')")
+    public R<Boolean> disable(@PathVariable @NotNull Long id) {
+        userService.updateEnabled(id, false);
+        return R.ok(true);
+    }
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysUserMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysUserMapper.java
@@ -1,9 +1,13 @@
 package com.xrcgs.iam.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.model.query.UserPageQuery;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface SysUserMapper extends BaseMapper<SysUser> {
+    Page<SysUser> selectPage(Page<SysUser> page, @Param("q") UserPageQuery query);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserUpsertDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserUpsertDTO.java
@@ -1,0 +1,48 @@
+package com.xrcgs.iam.model.dto;
+
+import com.xrcgs.iam.enums.DataScope;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 用户新增/修改请求体
+ */
+@Data
+public class UserUpsertDTO {
+
+    /**
+     * 主键，新增时忽略
+     */
+    private Long id;
+
+    @NotBlank(message = "用户名不能为空")
+    @Size(max = 64, message = "用户名长度不能超过64个字符")
+    private String username;
+
+    /**
+     * 登录密码，新增时必填，修改时为空表示不变
+     */
+    @Size(min = 6, max = 128, message = "密码长度需在6~128个字符之间")
+    private String password;
+
+    @NotBlank(message = "昵称不能为空")
+    @Size(max = 64, message = "昵称长度不能超过64个字符")
+    private String nickname;
+
+    private Boolean enabled;
+
+    private Long deptId;
+
+    private List<Long> extraDeptIds;
+
+    private DataScope dataScope;
+
+    /**
+     * 数据范围扩展，CUSTOM 模式下生效
+     */
+    private List<Long> dataScopeDeptIds;
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/query/UserPageQuery.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/query/UserPageQuery.java
@@ -1,0 +1,19 @@
+package com.xrcgs.iam.model.query;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 用户分页查询条件
+ */
+@Data
+public class UserPageQuery {
+    private String username;
+    private String nickname;
+    private Long deptId;
+    private Boolean enabled;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/UserVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/UserVO.java
@@ -1,0 +1,25 @@
+package com.xrcgs.iam.model.vo;
+
+import com.xrcgs.iam.enums.DataScope;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 用户详情/分页返回
+ */
+@Data
+public class UserVO {
+    private Long id;
+    private String username;
+    private String nickname;
+    private Boolean enabled;
+    private Long deptId;
+    private List<Long> extraDeptIds;
+    private DataScope dataScope;
+    private List<Long> dataScopeDeptIds;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
@@ -1,0 +1,22 @@
+package com.xrcgs.iam.service;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.xrcgs.iam.model.dto.UserUpsertDTO;
+import com.xrcgs.iam.model.query.UserPageQuery;
+import com.xrcgs.iam.model.vo.UserVO;
+
+public interface UserService {
+
+    Page<UserVO> page(UserPageQuery q, long pageNo, long pageSize);
+
+    UserVO detail(Long id);
+
+    Long create(UserUpsertDTO dto);
+
+    void update(Long id, UserUpsertDTO dto);
+
+    void delete(Long id);
+
+    void updateEnabled(Long id, boolean enabled);
+}
+

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
@@ -1,0 +1,238 @@
+package com.xrcgs.iam.service.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xrcgs.common.cache.AuthCacheService;
+import com.xrcgs.iam.datascope.DataScopeManager;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.enums.DataScope;
+import com.xrcgs.iam.mapper.SysUserMapper;
+import com.xrcgs.iam.model.dto.UserUpsertDTO;
+import com.xrcgs.iam.model.query.UserPageQuery;
+import com.xrcgs.iam.model.vo.UserVO;
+import com.xrcgs.iam.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private static final TypeReference<List<Long>> LONG_LIST_TYPE = new TypeReference<>() {
+    };
+
+    private final SysUserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthCacheService authCacheService;
+    private final DataScopeManager dataScopeManager;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Page<UserVO> page(UserPageQuery q, long pageNo, long pageSize) {
+        Page<SysUser> entityPage = userMapper.selectPage(new Page<>(pageNo, pageSize), q);
+        Page<UserVO> result = new Page<>(entityPage.getCurrent(), entityPage.getSize());
+        result.setTotal(entityPage.getTotal());
+        result.setPages(entityPage.getPages());
+        if (entityPage.getRecords() == null || entityPage.getRecords().isEmpty()) {
+            result.setRecords(Collections.emptyList());
+            return result;
+        }
+        result.setRecords(entityPage.getRecords().stream().map(this::toVO).collect(Collectors.toList()));
+        return result;
+    }
+
+    @Override
+    public UserVO detail(Long id) {
+        SysUser user = requireExisting(id);
+        return toVO(user);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Long create(UserUpsertDTO dto) {
+        String username = normalize(dto.getUsername());
+        if (!StringUtils.hasText(username)) {
+            throw new IllegalArgumentException("用户名不能为空");
+        }
+        ensureUsernameUnique(username, null);
+
+        String nickname = normalize(dto.getNickname());
+        if (!StringUtils.hasText(nickname)) {
+            throw new IllegalArgumentException("昵称不能为空");
+        }
+
+        String rawPassword = normalize(dto.getPassword());
+        if (!StringUtils.hasText(rawPassword)) {
+            throw new IllegalArgumentException("密码不能为空");
+        }
+
+        SysUser entity = new SysUser();
+        entity.setUsername(username);
+        entity.setNickname(nickname);
+        entity.setPassword(passwordEncoder.encode(rawPassword));
+        entity.setEnabled(dto.getEnabled() != null ? dto.getEnabled() : Boolean.TRUE);
+        entity.setDeptId(dto.getDeptId());
+        entity.setExtraDeptIds(serializeList(dto.getExtraDeptIds()));
+
+        DataScope dataScope = dto.getDataScope() != null ? dto.getDataScope() : DataScope.SELF;
+        entity.setDataScope(dataScope);
+        entity.setDataScopeExt(serializeDataScopeExt(dataScope, dto.getDataScopeDeptIds()));
+
+        userMapper.insert(entity);
+        return entity.getId();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void update(Long id, UserUpsertDTO dto) {
+        SysUser current = requireExisting(id);
+
+        String username = normalize(dto.getUsername());
+        if (!StringUtils.hasText(username)) {
+            throw new IllegalArgumentException("用户名不能为空");
+        }
+        ensureUsernameUnique(username, id);
+
+        String nickname = normalize(dto.getNickname());
+        if (!StringUtils.hasText(nickname)) {
+            throw new IllegalArgumentException("昵称不能为空");
+        }
+
+        SysUser update = new SysUser();
+        update.setId(id);
+        update.setUsername(username);
+        update.setNickname(nickname);
+        update.setEnabled(dto.getEnabled() != null ? dto.getEnabled() : current.getEnabled());
+        update.setDeptId(dto.getDeptId());
+
+        String extraDeptJson = dto.getExtraDeptIds() != null ? serializeList(dto.getExtraDeptIds()) : current.getExtraDeptIds();
+        update.setExtraDeptIds(extraDeptJson);
+
+        DataScope dataScope = dto.getDataScope() != null ? dto.getDataScope() : current.getDataScope();
+        update.setDataScope(dataScope);
+        List<Long> scopeDeptIds = dto.getDataScopeDeptIds() != null ? dto.getDataScopeDeptIds() : parseList(current.getDataScopeExt());
+        update.setDataScopeExt(serializeDataScopeExt(dataScope, scopeDeptIds));
+
+        String newPassword = normalize(dto.getPassword());
+        if (StringUtils.hasText(newPassword)) {
+            update.setPassword(passwordEncoder.encode(newPassword));
+        }
+
+        userMapper.updateById(update);
+        evictAuthCache(id);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void delete(Long id) {
+        requireExisting(id);
+        userMapper.deleteById(id);
+        evictAuthCache(id);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void updateEnabled(Long id, boolean enabled) {
+        requireExisting(id);
+        SysUser update = new SysUser();
+        update.setId(id);
+        update.setEnabled(enabled);
+        userMapper.updateById(update);
+        evictAuthCache(id);
+    }
+
+    private SysUser requireExisting(Long id) {
+        SysUser user = userMapper.selectById(id);
+        if (user == null) {
+            throw new IllegalArgumentException("用户不存在: " + id);
+        }
+        return user;
+    }
+
+    private void ensureUsernameUnique(String username, Long excludeId) {
+        Long count = userMapper.selectCount(Wrappers.<SysUser>lambdaQuery()
+                .eq(SysUser::getUsername, username)
+                .ne(excludeId != null, SysUser::getId, excludeId));
+        if (count != null && count > 0) {
+            throw new IllegalArgumentException("用户名已存在: " + username);
+        }
+    }
+
+    private String serializeList(List<Long> values) {
+        if (values == null) {
+            return null;
+        }
+        List<Long> sanitized = values.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        try {
+            return objectMapper.writeValueAsString(sanitized);
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 序列化失败", e);
+        }
+    }
+
+    private List<Long> parseList(String json) {
+        if (!StringUtils.hasText(json)) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(json, LONG_LIST_TYPE);
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 解析失败", e);
+        }
+    }
+
+    private String serializeDataScopeExt(DataScope scope, List<Long> deptIds) {
+        if (scope == null || scope != DataScope.CUSTOM) {
+            return null;
+        }
+        return serializeList(deptIds);
+    }
+
+    private UserVO toVO(SysUser entity) {
+        UserVO vo = new UserVO();
+        vo.setId(entity.getId());
+        vo.setUsername(entity.getUsername());
+        vo.setNickname(entity.getNickname());
+        vo.setEnabled(entity.getEnabled());
+        vo.setDeptId(entity.getDeptId());
+        vo.setExtraDeptIds(parseList(entity.getExtraDeptIds()));
+        vo.setDataScope(entity.getDataScope());
+        vo.setDataScopeDeptIds(parseList(entity.getDataScopeExt()));
+        vo.setCreatedAt(entity.getCreatedAt());
+        vo.setUpdatedAt(entity.getUpdatedAt());
+        return vo;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private void evictAuthCache(Long userId) {
+        try {
+            authCacheService.evictUserPerms(userId);
+        } catch (Exception ignored) {
+        }
+        try {
+            dataScopeManager.evictUserDataScope(userId);
+        } catch (Exception ignored) {
+        }
+    }
+}
+

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysUserMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysUserMapper.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xrcgs.iam.mapper.SysUserMapper">
+
+    <select id="selectPage" resultType="com.xrcgs.iam.entity.SysUser">
+        SELECT
+            id,
+            username,
+            password,
+            nickname,
+            enabled,
+            dept_id AS deptId,
+            extra_dept_ids AS extraDeptIds,
+            data_scope AS dataScope,
+            data_scope_ext AS dataScopeExt,
+            created_at AS createdAt,
+            updated_at AS updatedAt
+        FROM sys_user
+        WHERE 1 = 1
+        <if test="q != null">
+            <if test="q.username != null and q.username != ''">
+                AND username LIKE CONCAT('%', #{q.username}, '%')
+            </if>
+            <if test="q.nickname != null and q.nickname != ''">
+                AND nickname LIKE CONCAT('%', #{q.nickname}, '%')
+            </if>
+            <if test="q.deptId != null">
+                AND dept_id = #{q.deptId}
+            </if>
+            <if test="q.enabled != null">
+                AND enabled = #{q.enabled}
+            </if>
+            <if test="q.startTime != null">
+                AND created_at &gt;= #{q.startTime}
+            </if>
+            <if test="q.endTime != null">
+                AND created_at &lt;= #{q.endTime}
+            </if>
+        </if>
+        ORDER BY id DESC
+    </select>
+
+</mapper>

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/UserServiceImplTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/UserServiceImplTest.java
@@ -1,0 +1,292 @@
+package com.xrcgs.iam.service.impl;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xrcgs.common.cache.AuthCacheService;
+import com.xrcgs.iam.datascope.DataScopeManager;
+import com.xrcgs.iam.entity.SysUser;
+import com.xrcgs.iam.enums.DataScope;
+import com.xrcgs.iam.mapper.SysUserMapper;
+import com.xrcgs.iam.model.dto.UserUpsertDTO;
+import com.xrcgs.iam.model.query.UserPageQuery;
+import com.xrcgs.iam.model.vo.UserVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private SysUserMapper userMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthCacheService authCacheService;
+
+    @Mock
+    private DataScopeManager dataScopeManager;
+
+    private UserServiceImpl userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserServiceImpl(userMapper, passwordEncoder, authCacheService, dataScopeManager, new ObjectMapper());
+    }
+
+    @Test
+    void createShouldEncodePasswordAndPersist() {
+        UserUpsertDTO dto = new UserUpsertDTO();
+        dto.setUsername(" admin ");
+        dto.setPassword("plainPwd");
+        dto.setNickname(" 管理员 ");
+        dto.setEnabled(true);
+        dto.setDeptId(1L);
+        dto.setExtraDeptIds(Arrays.asList(10L, 20L));
+        dto.setDataScope(DataScope.CUSTOM);
+        dto.setDataScopeDeptIds(Arrays.asList(100L, 200L));
+
+        when(userMapper.selectCount(any())).thenReturn(0L);
+        when(passwordEncoder.encode("plainPwd")).thenReturn("encodedPwd");
+        doAnswer(invocation -> {
+            SysUser entity = invocation.getArgument(0);
+            entity.setId(5L);
+            return 1;
+        }).when(userMapper).insert(any(SysUser.class));
+
+        Long id = userService.create(dto);
+        assertEquals(5L, id);
+
+        ArgumentCaptor<SysUser> captor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).insert(captor.capture());
+        SysUser saved = captor.getValue();
+        assertEquals("admin", saved.getUsername());
+        assertEquals("管理员", saved.getNickname());
+        assertEquals("encodedPwd", saved.getPassword());
+        assertEquals(Boolean.TRUE, saved.getEnabled());
+        assertEquals(1L, saved.getDeptId());
+        assertEquals("[10,20]", saved.getExtraDeptIds());
+        assertEquals(DataScope.CUSTOM, saved.getDataScope());
+        assertEquals("[100,200]", saved.getDataScopeExt());
+    }
+
+    @Test
+    void createShouldRejectDuplicateUsername() {
+        UserUpsertDTO dto = new UserUpsertDTO();
+        dto.setUsername("admin");
+        dto.setPassword("plainPwd");
+        dto.setNickname("管理员");
+
+        when(userMapper.selectCount(any())).thenReturn(1L);
+
+        assertThrows(IllegalArgumentException.class, () -> userService.create(dto));
+        verify(userMapper, never()).insert(any());
+    }
+
+    @Test
+    void updateShouldEncodePasswordWhenProvided() {
+        SysUser current = new SysUser();
+        current.setId(10L);
+        current.setUsername("old");
+        current.setNickname("旧");
+        current.setEnabled(Boolean.TRUE);
+        current.setDeptId(2L);
+        current.setExtraDeptIds("[1]");
+        current.setDataScope(DataScope.SELF);
+        current.setDataScopeExt(null);
+
+        when(userMapper.selectById(10L)).thenReturn(current);
+        when(userMapper.selectCount(any())).thenReturn(0L);
+        when(passwordEncoder.encode("newPwd")).thenReturn("encodedNew");
+
+        UserUpsertDTO dto = new UserUpsertDTO();
+        dto.setUsername(" new ");
+        dto.setNickname(" 新 ");
+        dto.setPassword("newPwd");
+        dto.setEnabled(false);
+        dto.setDeptId(3L);
+        dto.setExtraDeptIds(Arrays.asList(5L, 6L));
+        dto.setDataScope(DataScope.CUSTOM);
+        dto.setDataScopeDeptIds(Arrays.asList(9L, 10L));
+
+        userService.update(10L, dto);
+
+        ArgumentCaptor<SysUser> captor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).updateById(captor.capture());
+        SysUser updated = captor.getValue();
+        assertEquals(10L, updated.getId());
+        assertEquals("new", updated.getUsername());
+        assertEquals("新", updated.getNickname());
+        assertEquals(Boolean.FALSE, updated.getEnabled());
+        assertEquals(3L, updated.getDeptId());
+        assertEquals("[5,6]", updated.getExtraDeptIds());
+        assertEquals(DataScope.CUSTOM, updated.getDataScope());
+        assertEquals("[9,10]", updated.getDataScopeExt());
+        assertEquals("encodedNew", updated.getPassword());
+
+        verify(authCacheService).evictUserPerms(10L);
+        verify(dataScopeManager).evictUserDataScope(10L);
+    }
+
+    @Test
+    void updateShouldKeepPasswordAndJsonWhenMissing() {
+        SysUser current = new SysUser();
+        current.setId(11L);
+        current.setUsername("old");
+        current.setNickname("旧");
+        current.setEnabled(Boolean.TRUE);
+        current.setDeptId(4L);
+        current.setExtraDeptIds("[3]");
+        current.setDataScope(DataScope.CUSTOM);
+        current.setDataScopeExt("[7]");
+
+        when(userMapper.selectById(11L)).thenReturn(current);
+        when(userMapper.selectCount(any())).thenReturn(0L);
+
+        UserUpsertDTO dto = new UserUpsertDTO();
+        dto.setUsername("newer");
+        dto.setNickname("更新");
+        dto.setPassword(null);
+        dto.setEnabled(null);
+        dto.setDeptId(5L);
+        dto.setExtraDeptIds(null);
+        dto.setDataScope(null);
+        dto.setDataScopeDeptIds(null);
+
+        userService.update(11L, dto);
+
+        ArgumentCaptor<SysUser> captor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).updateById(captor.capture());
+        SysUser updated = captor.getValue();
+        assertEquals(11L, updated.getId());
+        assertNull(updated.getPassword());
+        assertEquals("[3]", updated.getExtraDeptIds());
+        assertEquals(DataScope.CUSTOM, updated.getDataScope());
+        assertEquals("[7]", updated.getDataScopeExt());
+        assertEquals(Boolean.TRUE, updated.getEnabled());
+
+        verify(passwordEncoder, never()).encode(any());
+        verify(authCacheService).evictUserPerms(11L);
+        verify(dataScopeManager).evictUserDataScope(11L);
+    }
+
+    @Test
+    void updateEnabledShouldToggleStatus() {
+        SysUser current = new SysUser();
+        current.setId(15L);
+        current.setEnabled(Boolean.TRUE);
+
+        when(userMapper.selectById(15L)).thenReturn(current);
+
+        userService.updateEnabled(15L, false);
+
+        ArgumentCaptor<SysUser> captor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).updateById(captor.capture());
+        SysUser updated = captor.getValue();
+        assertEquals(15L, updated.getId());
+        assertEquals(Boolean.FALSE, updated.getEnabled());
+
+        verify(authCacheService).evictUserPerms(15L);
+        verify(dataScopeManager).evictUserDataScope(15L);
+    }
+
+    @Test
+    void deleteShouldRemoveUserAndEvictCaches() {
+        SysUser current = new SysUser();
+        current.setId(20L);
+
+        when(userMapper.selectById(20L)).thenReturn(current);
+
+        userService.delete(20L);
+
+        verify(userMapper).deleteById(20L);
+        verify(authCacheService).evictUserPerms(20L);
+        verify(dataScopeManager).evictUserDataScope(20L);
+    }
+
+    @Test
+    void pageShouldConvertEntitiesToVo() {
+        SysUser record = new SysUser();
+        record.setId(1L);
+        record.setUsername("alice");
+        record.setNickname("Alice");
+        record.setEnabled(Boolean.TRUE);
+        record.setDeptId(9L);
+        record.setExtraDeptIds("[30,40]");
+        record.setDataScope(DataScope.CUSTOM);
+        record.setDataScopeExt("[50]");
+        record.setCreatedAt(LocalDateTime.of(2024, 1, 1, 10, 0));
+        record.setUpdatedAt(LocalDateTime.of(2024, 1, 2, 10, 0));
+
+        Page<SysUser> mpPage = new Page<>(1, 10);
+        mpPage.setTotal(1);
+        mpPage.setPages(1);
+        mpPage.setRecords(Collections.singletonList(record));
+
+        when(userMapper.selectPage(any(Page.class), any())).thenReturn(mpPage);
+
+        UserPageQuery query = new UserPageQuery();
+        query.setUsername("alice");
+
+        Page<UserVO> result = userService.page(query, 1, 10);
+
+        assertEquals(1, result.getTotal());
+        assertEquals(1, result.getCurrent());
+        assertEquals(10, result.getSize());
+        assertEquals(1, result.getRecords().size());
+        UserVO vo = result.getRecords().get(0);
+        assertEquals("alice", vo.getUsername());
+        assertEquals("Alice", vo.getNickname());
+        assertEquals(Boolean.TRUE, vo.getEnabled());
+        assertEquals(9L, vo.getDeptId());
+        assertEquals(List.of(30L, 40L), vo.getExtraDeptIds());
+        assertEquals(DataScope.CUSTOM, vo.getDataScope());
+        assertEquals(List.of(50L), vo.getDataScopeDeptIds());
+        assertEquals(record.getCreatedAt(), vo.getCreatedAt());
+        assertEquals(record.getUpdatedAt(), vo.getUpdatedAt());
+    }
+
+    @Test
+    void detailShouldReturnVo() {
+        SysUser record = new SysUser();
+        record.setId(8L);
+        record.setUsername("bob");
+        record.setNickname("Bob");
+        record.setEnabled(Boolean.FALSE);
+        record.setDeptId(12L);
+        record.setExtraDeptIds("[1,2]");
+        record.setDataScope(DataScope.SELF);
+        record.setDataScopeExt(null);
+        record.setCreatedAt(LocalDateTime.now());
+        record.setUpdatedAt(LocalDateTime.now());
+
+        when(userMapper.selectById(8L)).thenReturn(record);
+
+        UserVO vo = userService.detail(8L);
+        assertEquals("bob", vo.getUsername());
+        assertEquals(Boolean.FALSE, vo.getEnabled());
+        assertEquals(List.of(1L, 2L), vo.getExtraDeptIds());
+        assertEquals(Collections.emptyList(), vo.getDataScopeDeptIds());
+    }
+
+    @Test
+    void detailShouldThrowWhenNotFound() {
+        when(userMapper.selectById(999L)).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> userService.detail(999L));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add user DTOs/VOs and expose CRUD plus enable/disable endpoints through a new user controller
- implement UserService with JSON field handling, password hashing, and pagination backed by a custom mapper query
- add mapper XML and Mockito-based unit tests that exercise user CRUD flows

## Testing
- mvn -pl xrcgs-module-iam test *(fails: unable to reach Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ce47a7d9e8832186a90b7297053d0a