### PR TITLE
feat(iam): support nickname suffix search

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Validated
 @RestController
 @RequestMapping("/api/iam/user")
@@ -28,6 +30,12 @@ public class UserController {
                                 @RequestParam(defaultValue = "1") long pageNo,
                                 @RequestParam(defaultValue = "10") long pageSize) {
         return R.ok(userService.page(query, pageNo, pageSize));
+    }
+
+    @GetMapping("/search-by-nickname")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:list')")
+    public R<List<UserVO>> searchByNickname(@RequestParam String nickname) {
+        return R.ok(userService.listByNicknameSuffix(nickname));
     }
 
     @GetMapping("/{id}")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysUserMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysUserMapper.java
@@ -7,7 +7,11 @@ import com.xrcgs.iam.model.query.UserPageQuery;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface SysUserMapper extends BaseMapper<SysUser> {
     Page<SysUser> selectPage(Page<SysUser> page, @Param("q") UserPageQuery query);
+
+    List<SysUser> selectByNicknameSuffix(@Param("nickname") String nickname);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
@@ -5,6 +5,8 @@ import com.xrcgs.iam.model.dto.UserUpsertDTO;
 import com.xrcgs.iam.model.query.UserPageQuery;
 import com.xrcgs.iam.model.vo.UserVO;
 
+import java.util.List;
+
 public interface UserService {
 
     Page<UserVO> page(UserPageQuery q, long pageNo, long pageSize);
@@ -18,5 +20,7 @@ public interface UserService {
     void delete(Long id);
 
     void updateEnabled(Long id, boolean enabled);
+
+    List<UserVO> listByNicknameSuffix(String nickname);
 }
 

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
@@ -151,6 +151,19 @@ public class UserServiceImpl implements UserService {
         evictAuthCache(id);
     }
 
+    @Override
+    public List<UserVO> listByNicknameSuffix(String nickname) {
+        String normalized = normalize(nickname);
+        if (!StringUtils.hasText(normalized)) {
+            return Collections.emptyList();
+        }
+        List<SysUser> users = userMapper.selectByNicknameSuffix(normalized);
+        if (users == null || users.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return users.stream().map(this::toVO).collect(Collectors.toList());
+    }
+
     private SysUser requireExisting(Long id) {
         SysUser user = userMapper.selectById(id);
         if (user == null) {

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysUserMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysUserMapper.xml
@@ -41,4 +41,22 @@
         ORDER BY id DESC
     </select>
 
+    <select id="selectByNicknameSuffix" resultType="com.xrcgs.iam.entity.SysUser">
+        SELECT
+            id,
+            username,
+            password,
+            nickname,
+            enabled,
+            dept_id AS deptId,
+            extra_dept_ids AS extraDeptIds,
+            data_scope AS dataScope,
+            data_scope_ext AS dataScopeExt,
+            created_at AS createdAt,
+            updated_at AS updatedAt
+        FROM sys_user
+        WHERE nickname LIKE CONCAT(#{nickname}, '%')
+        ORDER BY id DESC
+    </select>
+
 </mapper>

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/UserServiceImplTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/UserServiceImplTest.java
@@ -288,5 +288,46 @@ class UserServiceImplTest {
         when(userMapper.selectById(999L)).thenReturn(null);
         assertThrows(IllegalArgumentException.class, () -> userService.detail(999L));
     }
+
+    @Test
+    void listByNicknameSuffixShouldReturnConvertedUsers() {
+        SysUser user = new SysUser();
+        user.setId(30L);
+        user.setUsername("nickuser");
+        user.setNickname("Nick");
+        user.setEnabled(Boolean.TRUE);
+        user.setDeptId(7L);
+        user.setExtraDeptIds("[5,6]");
+        user.setDataScope(DataScope.CUSTOM);
+        user.setDataScopeExt("[101,102]");
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+
+        when(userMapper.selectByNicknameSuffix("Nick")).thenReturn(List.of(user));
+
+        List<UserVO> result = userService.listByNicknameSuffix(" Nick ");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        UserVO vo = result.get(0);
+        assertEquals(user.getId(), vo.getId());
+        assertEquals(user.getUsername(), vo.getUsername());
+        assertEquals(user.getNickname(), vo.getNickname());
+        assertEquals(user.getEnabled(), vo.getEnabled());
+        assertEquals(user.getDeptId(), vo.getDeptId());
+        assertEquals(List.of(5L, 6L), vo.getExtraDeptIds());
+        assertEquals(DataScope.CUSTOM, vo.getDataScope());
+        assertEquals(List.of(101L, 102L), vo.getDataScopeDeptIds());
+        verify(userMapper).selectByNicknameSuffix("Nick");
+    }
+
+    @Test
+    void listByNicknameSuffixShouldReturnEmptyWhenNicknameBlank() {
+        List<UserVO> result = userService.listByNicknameSuffix("   ");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(userMapper, never()).selectByNicknameSuffix(any());
+    }
 }
 


### PR DESCRIPTION
## Summary
- add a nickname suffix query to the user service and mapper
- expose a GET endpoint to search users by nickname prefix
- cover the new service method with unit tests

## Testing
- mvn -pl xrcgs-module-iam test *(fails: unable to reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4bbd667c8321a6d4f6a600bfc958