### PR TITLE
Update dept tree leader representation

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptTreeVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptTreeVO.java
@@ -19,11 +19,17 @@ public class DeptTreeVO {
     private Integer status;
     private Integer sortNo;
     private String path;
-    private Long leaderUserId;
+    private LeaderUser leaderUser;
     private String phone;
     private String email;
     private String remark;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createTime;
     private final List<DeptTreeVO> children = new ArrayList<>();
+
+    @Data
+    public static class LeaderUser {
+        private Long id;
+        private String name;
+    }
 }


### PR DESCRIPTION
## Summary
- replace the dept tree leader id with a nested LeaderUser view containing id and display name
- inject SysUserMapper into DeptServiceImpl to batch load leader users and attach them to tree nodes
- update DeptServiceImplTest to mock SysUserMapper and validate the new leader user data in the tree

## Testing
- mvn -pl xrcgs-module-iam test -Dtest=DeptServiceImplTest *(fails: unable to reach Maven Central to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9a989be88321b4b1925364596754