### PR TITLE
feat(iam): support filtering dept tree by name

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DeptController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DeptController.java
@@ -28,8 +28,9 @@ public class DeptController {
 
     @GetMapping("/tree")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dept:tree')")
-    public R<List<DeptTreeVO>> tree(@RequestParam(value = "status", required = false) Integer status) {
-        return R.ok(deptService.tree(status));
+    public R<List<DeptTreeVO>> tree(@RequestParam(value = "name", required = false) String name,
+                                    @RequestParam(value = "status", required = false) Integer status) {
+        return R.ok(deptService.tree(name, status));
     }
 
     @GetMapping("/{id}")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DeptService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DeptService.java
@@ -16,5 +16,5 @@ public interface DeptService {
 
     DeptVO detail(Long id);
 
-    List<DeptTreeVO> tree(Integer status);
+    List<DeptTreeVO> tree(String name, Integer status);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DeptServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DeptServiceImpl.java
@@ -36,10 +36,12 @@ public class DeptServiceImpl implements DeptService {
     private final StringRedisTemplate stringRedisTemplate;
 
     @Override
-    public List<DeptTreeVO> tree(Integer status) {
+    public List<DeptTreeVO> tree(String name, Integer status) {
+        String keyword = StringUtils.hasText(name) ? name.trim() : null;
         List<SysDept> list = deptMapper.selectList(
                 Wrappers.<SysDept>lambdaQuery()
                         .eq(SysDept::getDelFlag, 0)
+                        .like(StringUtils.hasText(keyword), SysDept::getName, keyword)
                         .eq(status != null, SysDept::getStatus, status)
                         .orderByAsc(SysDept::getSortNo, SysDept::getId)
         );

--- a/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
+++ b/xrcgs-module-iam/src/test/java/com/xrcgs/iam/service/impl/DeptServiceImplTest.java
@@ -201,7 +201,7 @@ class DeptServiceImplTest {
         childLeader.setNickname("李四");
         when(userMapper.selectBatchIds(anyCollection())).thenReturn(Arrays.asList(rootLeader, childLeader));
 
-        List<DeptTreeVO> tree = deptService.tree(null);
+        List<DeptTreeVO> tree = deptService.tree(null, null);
         assertEquals(1, tree.size());
         DeptTreeVO rootNode = tree.get(0);
         assertEquals("根", rootNode.getName());


### PR DESCRIPTION
## Summary
- add an optional name request parameter to the department tree endpoint and propagate the signature change through the service layer
- extend the department tree query with a conditional name filter and update the existing unit test to match the new signature

## Testing
- mvn -pl xrcgs-module-iam -am test *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-dependencies:pom:3.4.7)*

------
https://chatgpt.com/codex/tasks/task_e_68cea94d6ba48321b126ed5260fadc96