### PR TITLE
Add department details to user view objects

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptBriefVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/DeptBriefVO.java
@@ -1,0 +1,12 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+/**
+ * 部门简要信息
+ */
+@Data
+public class DeptBriefVO {
+    private Long id;
+    private String name;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/UserVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/UserVO.java
@@ -18,7 +18,7 @@ public class UserVO {
     private String wechatId;
     private String phone;
     private Boolean enabled;
-    private Long deptId;
+    private DeptBriefVO dept;
     private List<Long> extraDeptIds;
     private DataScope dataScope;
     private List<Long> dataScopeDeptIds;
@@ -27,4 +27,3 @@ public class UserVO {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime updatedAt;
 }
-


### PR DESCRIPTION
## Summary
- replace the primitive department id in `UserVO` with a `DeptBriefVO` carrying both id and name
- batch load department entities via `SysDeptMapper` so `UserServiceImpl` populates department names for page, detail, and suffix queries
- extend `UserServiceImplTest` to mock department lookups and assert the returned department id and name

## Testing
- `mvn -pl xrcgs-module-iam test` *(fails: missing dependent modules `com.xrcgs:xrcgs-common`, `com.xrcgs:xrcgs-infrastructure`, `com.xrcgs:xrcgs-module-syslog`)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b1617b50832183151dd1a7f1133c