### PR TITLE
feat: handle user role associations in IAM user upsert

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserUpsertDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserUpsertDTO.java
@@ -56,5 +56,10 @@ public class UserUpsertDTO {
      * 数据范围扩展，CUSTOM 模式下生效
      */
     private List<Long> dataScopeDeptIds;
+
+    /**
+     * 关联角色 ID 列表
+     */
+    private List<Long> roleIds;
 }
 


### PR DESCRIPTION
## Summary
- add a roleIds field to the user upsert DTO so requests can include role assignments
- inject SysUserRoleMapper into UserServiceImpl and add a helper to sanitize and persist role links
- update create and update flows to insert or rebuild user-role relations when saving a user

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7d091d4d08321bd2045f52e4f3ac6