### PR TITLE
feat(iam): add dedicated endpoints for password reset and role assignment

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/UserController.java
@@ -2,6 +2,8 @@ package com.xrcgs.iam.controller;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.xrcgs.common.core.R;
+import com.xrcgs.iam.model.dto.UserAssignRoleDTO;
+import com.xrcgs.iam.model.dto.UserResetPasswordDTO;
 import com.xrcgs.iam.model.dto.UserUpsertDTO;
 import com.xrcgs.iam.model.query.UserPageQuery;
 import com.xrcgs.iam.model.vo.UserVO;
@@ -59,6 +61,24 @@ public class UserController {
                              @Valid @RequestBody UserUpsertDTO dto) {
         dto.setId(id);
         userService.update(id, dto);
+        return R.ok(true);
+    }
+
+    @PutMapping("/{id}/password")
+    @OpLog("重置用户密码")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:update')")
+    public R<Boolean> resetPassword(@PathVariable @NotNull Long id,
+                                    @Valid @RequestBody UserResetPasswordDTO dto) {
+        userService.resetPassword(id, dto.getPassword());
+        return R.ok(true);
+    }
+
+    @PutMapping("/{id}/roles")
+    @OpLog("分配用户角色")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:user:update')")
+    public R<Boolean> assignRoles(@PathVariable @NotNull Long id,
+                                  @Valid @RequestBody UserAssignRoleDTO dto) {
+        userService.assignRoles(id, dto.getRoleIds());
         return R.ok(true);
     }
 

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserAssignRoleDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserAssignRoleDTO.java
@@ -1,0 +1,19 @@
+package com.xrcgs.iam.model.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 用户分配角色请求体
+ */
+@Data
+public class UserAssignRoleDTO {
+
+    /**
+     * 角色 ID 列表，允许为空列表表示清空角色
+     */
+    @NotNull(message = "角色列表不能为空")
+    private List<Long> roleIds;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserResetPasswordDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/UserResetPasswordDTO.java
@@ -1,0 +1,16 @@
+package com.xrcgs.iam.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 用户重置密码请求体
+ */
+@Data
+public class UserResetPasswordDTO {
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, max = 128, message = "密码长度需在6~128个字符之间")
+    private String password;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/UserService.java
@@ -21,6 +21,10 @@ public interface UserService {
 
     void updateEnabled(Long id, boolean enabled);
 
+    void resetPassword(Long id, String rawPassword);
+
+    void assignRoles(Long id, List<Long> roleIds);
+
     List<UserVO> listByNicknameSuffix(String nickname);
 }
 

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
@@ -163,6 +163,30 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(rollbackFor = Exception.class)
+    public void resetPassword(Long id, String rawPassword) {
+        requireExisting(id);
+        String normalized = normalize(rawPassword);
+        if (!StringUtils.hasText(normalized)) {
+            throw new IllegalArgumentException("密码不能为空");
+        }
+        SysUser update = new SysUser();
+        update.setId(id);
+        update.setPassword(passwordEncoder.encode(normalized));
+        userMapper.updateById(update);
+        evictAuthCache(id);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void assignRoles(Long id, List<Long> roleIds) {
+        requireExisting(id);
+        userRoleMapper.delete(Wrappers.<SysUserRole>lambdaQuery().eq(SysUserRole::getUserId, id));
+        saveUserRoles(id, roleIds);
+        evictAuthCache(id);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
     public void delete(Long id) {
         requireExisting(id);
         userMapper.deleteById(id);


### PR DESCRIPTION
## Summary
- add REST endpoints for resetting user passwords and assigning roles without requiring full user payloads
- introduce DTOs for password reset and role assignment requests
- implement service-layer helpers to update passwords and role relations with cache eviction

## Testing
- mvn -pl xrcgs-module-iam -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d7fff4b5c08321a5f245581bbe880e