### PR TITLE
Clean up user-role links when deleting users

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/UserServiceImpl.java
@@ -189,6 +189,7 @@ public class UserServiceImpl implements UserService {
     @Transactional(rollbackFor = Exception.class)
     public void delete(Long id) {
         requireExisting(id);
+        userRoleMapper.delete(Wrappers.<SysUserRole>lambdaQuery().eq(SysUserRole::getUserId, id));
         userMapper.deleteById(id);
         evictAuthCache(id);
     }


### PR DESCRIPTION
## Summary
- remove user role mappings when deleting a user to avoid orphaned relations

## Testing
- ⚠️ `mvn -pl xrcgs-module-iam test` *(fails: missing dependent modules in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8070c517c8321ae65d291fa7db898