### PR TITLE
Add deptId to role upsert and auto-generate role sort numbers

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysRoleMapper.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/mapper/SysRoleMapper.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface SysRoleMapper extends BaseMapper<SysRole> {
     Page<SysRole> selectPage(Page<SysRole> page, @Param("q") RolePageQuery q);
     List<Long> selectIdsByCodes(@Param("codes") List<String> codes);
+
+    Integer selectMaxSortNo();
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/RoleUpsertDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/RoleUpsertDTO.java
@@ -14,6 +14,7 @@ public class RoleUpsertDTO {
     private String code;
     private String name;
     private Integer status;
+    private Long deptId;
     private Integer sortNo;
     private DataScope dataScope; // ALL/DEPT/DEPT_AND_CHILD/SELF/CUSTOM
     private List<Long> dataScopeDeptIds; // CUSTOM 时有效

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysRoleMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysRoleMapper.xml
@@ -5,7 +5,7 @@
 
     <select id="selectPage" resultType="com.xrcgs.iam.entity.SysRole">
         SELECT
-        id, code, name, status, data_scope AS dataScope, data_scope_ext AS dataScopeExt,
+        id, code, name, status, dept_id AS deptId, data_scope AS dataScope, data_scope_ext AS dataScopeExt,
         remark, sort_no AS sortNo, create_by AS createBy, create_time AS createTime,
         update_by AS updateBy, update_time AS updateTime, del_flag AS delFlag
         FROM sys_role
@@ -35,6 +35,10 @@
             #{code}
         </foreach>
           AND del_flag = 0
+    </select>
+
+    <select id="selectMaxSortNo" resultType="java.lang.Integer">
+        SELECT MAX(sort_no) FROM sys_role WHERE del_flag = 0
     </select>
 
 </mapper>


### PR DESCRIPTION
## Summary
- include the deptId attribute in role upsert DTOs and persist it when saving roles
- automatically compute the next sort number for new roles when no sort value is provided
- extend the role mapper to fetch the maximum sort value and expose dept ids in paged queries

## Testing
- mvn -pl xrcgs-module-iam -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d945778e10832193724262017ff232