### PR TITLE
feat: add permission listing endpoint for role assignment

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
@@ -1,0 +1,26 @@
+package com.xrcgs.iam.controller;
+
+import com.xrcgs.common.core.R;
+import com.xrcgs.iam.model.vo.PermissionVO;
+import com.xrcgs.iam.service.PermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/iam/permission")
+@RequiredArgsConstructor
+public class PermissionController {
+
+    private final PermissionService permissionService;
+
+    @GetMapping("/list")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
+    public R<List<PermissionVO>> listAll() {
+        return R.ok(permissionService.listAll());
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/PermissionVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/PermissionVO.java
@@ -1,0 +1,13 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+/**
+ * 独立权限返回对象
+ */
+@Data
+public class PermissionVO {
+    private Long id;
+    private String code;
+    private String name;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/PermissionService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/PermissionService.java
@@ -1,0 +1,12 @@
+package com.xrcgs.iam.service;
+
+import com.xrcgs.iam.model.vo.PermissionVO;
+
+import java.util.List;
+
+public interface PermissionService {
+    /**
+     * 查询所有独立权限
+     */
+    List<PermissionVO> listAll();
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermissionServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermissionServiceImpl.java
@@ -1,0 +1,33 @@
+package com.xrcgs.iam.service.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.xrcgs.iam.entity.SysPermission;
+import com.xrcgs.iam.mapper.SysPermissionMapper;
+import com.xrcgs.iam.model.vo.PermissionVO;
+import com.xrcgs.iam.service.PermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PermissionServiceImpl implements PermissionService {
+
+    private final SysPermissionMapper permissionMapper;
+
+    @Override
+    public List<PermissionVO> listAll() {
+        List<SysPermission> permissions = permissionMapper.selectList(
+                Wrappers.<SysPermission>lambdaQuery().orderByAsc(SysPermission::getId)
+        );
+        return permissions.stream().map(permission -> {
+            PermissionVO vo = new PermissionVO();
+            vo.setId(permission.getId());
+            vo.setCode(permission.getCode());
+            vo.setName(permission.getName());
+            return vo;
+        }).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated permission controller and service to expose the full sys_permission list for role assignment
- introduce a PermissionVO response object for the new endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9324917788321bc20f8c0f8365b94