### PR TITLE
feat: extend sys_permission management endpoints

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
@@ -1,0 +1,61 @@
+package com.xrcgs.iam.controller;
+
+import com.xrcgs.common.core.R;
+import com.xrcgs.iam.model.dto.PermissionUpsertDTO;
+import com.xrcgs.iam.model.vo.PermissionVO;
+import com.xrcgs.iam.service.PermissionService;
+import com.xrcgs.syslog.annotation.OpLog;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/api/iam/permission")
+@RequiredArgsConstructor
+public class PermissionController {
+
+    private final PermissionService permissionService;
+
+    @GetMapping("/list")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
+    public R<List<PermissionVO>> list(@RequestParam(value = "name", required = false) String name) {
+        return R.ok(permissionService.list(name));
+    }
+
+    @PostMapping
+    @OpLog("新增独立权限")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:permission:create')")
+    public R<Long> create(@Valid @RequestBody PermissionUpsertDTO dto) {
+        return R.ok(permissionService.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    @OpLog("修改独立权限")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:permission:update')")
+    public R<Boolean> update(@PathVariable @NotNull Long id, @Valid @RequestBody PermissionUpsertDTO dto) {
+        permissionService.update(id, dto);
+        return R.ok(true);
+    }
+
+    @DeleteMapping("/{id}")
+    @OpLog("删除独立权限")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:permission:delete')")
+    public R<Boolean> delete(@PathVariable @NotNull Long id) {
+        permissionService.remove(id);
+        return R.ok(true);
+    }
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/PermissionUpsertDTO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/dto/PermissionUpsertDTO.java
@@ -1,0 +1,20 @@
+package com.xrcgs.iam.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 独立权限新增/修改 DTO
+ */
+@Data
+public class PermissionUpsertDTO {
+
+    @NotBlank(message = "权限编码不能为空")
+    @Size(max = 128, message = "权限编码长度不能超过128个字符")
+    private String code;
+
+    @NotBlank(message = "权限名称不能为空")
+    @Size(max = 64, message = "权限名称长度不能超过64个字符")
+    private String name;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/PermissionVO.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/model/vo/PermissionVO.java
@@ -1,0 +1,13 @@
+package com.xrcgs.iam.model.vo;
+
+import lombok.Data;
+
+/**
+ * 独立权限返回对象
+ */
+@Data
+public class PermissionVO {
+    private Long id;
+    private String code;
+    private String name;
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/PermissionService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/PermissionService.java
@@ -1,0 +1,19 @@
+package com.xrcgs.iam.service;
+
+import com.xrcgs.iam.model.dto.PermissionUpsertDTO;
+import com.xrcgs.iam.model.vo.PermissionVO;
+
+import java.util.List;
+
+public interface PermissionService {
+    /**
+     * 按名称查询独立权限
+     */
+    List<PermissionVO> list(String name);
+
+    Long create(PermissionUpsertDTO dto);
+
+    void update(Long id, PermissionUpsertDTO dto);
+
+    void remove(Long id);
+}

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermissionServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/PermissionServiceImpl.java
@@ -1,0 +1,150 @@
+package com.xrcgs.iam.service.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.xrcgs.iam.entity.SysPermission;
+import com.xrcgs.iam.entity.SysRolePerm;
+import com.xrcgs.iam.mapper.SysPermissionMapper;
+import com.xrcgs.iam.mapper.SysRolePermMapper;
+import com.xrcgs.iam.model.dto.PermissionUpsertDTO;
+import com.xrcgs.iam.model.vo.PermissionVO;
+import com.xrcgs.iam.service.PermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PermissionServiceImpl implements PermissionService {
+
+    private final SysPermissionMapper permissionMapper;
+    private final SysRolePermMapper rolePermMapper;
+
+    @Override
+    public List<PermissionVO> list(String name) {
+        String keyword = null;
+        boolean prefix = false;
+        if (StringUtils.hasText(name)) {
+            String normalized = name.trim();
+            if (normalized.endsWith("*")) {
+                prefix = true;
+                normalized = normalized.substring(0, normalized.length() - 1).trim();
+            }
+            keyword = StringUtils.hasText(normalized) ? normalized : null;
+        }
+
+        List<SysPermission> permissions = permissionMapper.selectList(
+                Wrappers.<SysPermission>lambdaQuery()
+                        .likeRight(prefix && keyword != null, SysPermission::getName, keyword)
+                        .eq(!prefix && keyword != null, SysPermission::getName, keyword)
+                        .orderByAsc(SysPermission::getId)
+        );
+        if (permissions == null || permissions.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return permissions.stream().map(this::toVO).collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Long create(PermissionUpsertDTO dto) {
+        String code = normalize(dto.getCode());
+        String name = normalize(dto.getName());
+
+        if (!StringUtils.hasText(code)) {
+            throw new IllegalArgumentException("权限编码不能为空");
+        }
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("权限名称不能为空");
+        }
+
+        ensureCodeUnique(code, null);
+        ensureNameUnique(name, null);
+
+        SysPermission entity = new SysPermission();
+        entity.setCode(code);
+        entity.setName(name);
+        permissionMapper.insert(entity);
+        return entity.getId();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void update(Long id, PermissionUpsertDTO dto) {
+        SysPermission current = require(id);
+
+        String code = normalize(dto.getCode());
+        String name = normalize(dto.getName());
+        if (!StringUtils.hasText(code)) {
+            throw new IllegalArgumentException("权限编码不能为空");
+        }
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("权限名称不能为空");
+        }
+
+        ensureCodeUnique(code, id);
+        ensureNameUnique(name, id);
+
+        SysPermission update = new SysPermission();
+        update.setId(current.getId());
+        update.setCode(code);
+        update.setName(name);
+        permissionMapper.updateById(update);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void remove(Long id) {
+        require(id);
+        permissionMapper.deleteById(id);
+        rolePermMapper.delete(
+                Wrappers.<SysRolePerm>lambdaQuery().eq(SysRolePerm::getPermId, id)
+        );
+    }
+
+    private PermissionVO toVO(SysPermission permission) {
+        PermissionVO vo = new PermissionVO();
+        vo.setId(permission.getId());
+        vo.setCode(permission.getCode());
+        vo.setName(permission.getName());
+        return vo;
+    }
+
+    private SysPermission require(Long id) {
+        SysPermission permission = permissionMapper.selectById(id);
+        if (permission == null) {
+            throw new IllegalArgumentException("权限不存在");
+        }
+        return permission;
+    }
+
+    private void ensureCodeUnique(String code, Long excludeId) {
+        Long count = permissionMapper.selectCount(
+                Wrappers.<SysPermission>lambdaQuery()
+                        .eq(SysPermission::getCode, code)
+                        .ne(excludeId != null, SysPermission::getId, excludeId)
+        );
+        if (count != null && count > 0) {
+            throw new IllegalStateException("权限编码已存在");
+        }
+    }
+
+    private void ensureNameUnique(String name, Long excludeId) {
+        Long count = permissionMapper.selectCount(
+                Wrappers.<SysPermission>lambdaQuery()
+                        .eq(SysPermission::getName, name)
+                        .ne(excludeId != null, SysPermission::getId, excludeId)
+        );
+        if (count != null && count > 0) {
+            throw new IllegalStateException("权限名称已存在");
+        }
+    }
+
+    private String normalize(String text) {
+        return text == null ? null : text.trim();
+    }
+}


### PR DESCRIPTION
## Summary
- add a name-filterable listing endpoint for independent permissions with optional wildcard suffix matching
- introduce DTO-backed create, update, and delete APIs for sys_permission management
- validate uniqueness and cascade role-permission cleanup inside the permission service implementation

## Testing
- mvn -pl xrcgs-module-iam -am test *(fails: org.mockito.exceptions.misusing.UnnecessaryStubbingException in DeptServiceImplTest due to pre-existing test configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9324917788321bc20f8c0f8365b94