### PR TITLE
feat: support prefix search in permission list

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +35,14 @@ public class PermissionController {
     @GetMapping("/list")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
     public R<List<PermissionVO>> list(@RequestParam(value = "name", required = false) String name) {
-        return R.ok(permissionService.list(name));
+        String keyword = null;
+        if (StringUtils.hasText(name)) {
+            String normalized = name.trim();
+            if (StringUtils.hasText(normalized)) {
+                keyword = normalized.endsWith("*") ? normalized : normalized + "*";
+            }
+        }
+        return R.ok(permissionService.list(keyword));
     }
 
     @PostMapping


### PR DESCRIPTION
## Summary
- normalize the permission list filter name in `PermissionController`
- ensure prefix searches append a trailing wildcard to leverage indexed lookups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da05b9c4588321a0bec7e77928b521