### PR TITLE
feat: support prefix search in permission list

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/PermissionController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +35,14 @@ public class PermissionController {
     @GetMapping("/list")
     @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:role:grantPerm')")
     public R<List<PermissionVO>> list(@RequestParam(value = "name", required = false) String name) {
-        return R.ok(permissionService.list(name));
+        String keyword = null;
+        if (StringUtils.hasText(name)) {
+            String normalized = name.trim();
+            if (StringUtils.hasText(normalized)) {
+                keyword = normalized.endsWith("*") ? normalized : normalized + "*";
+            }
+        }
+        return R.ok(permissionService.list(keyword));
     }
 
     @PostMapping

--- a/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
+++ b/xrcgs-module-iam/src/main/resources/mapper/iam/SysMenuMapper.xml
@@ -25,7 +25,7 @@
 
     <select id="selectListByQuery" resultMap="MenuMap">
         SELECT id, parent_id, title, router_name, path, component, type, perms,
-               icon, rank, keep_alive, show_parent, visible, status,
+               icon, rank, keep_alive, show_parent, visible, `status`,
                created_at, updated_at, del_flag
         FROM sys_menu
         WHERE del_flag = 0
@@ -36,7 +36,7 @@
                 OR perms LIKE CONCAT('%', #{q.keyword}, '%'))
             </if>
             <if test="q.status != null">
-                AND status = #{q.status}
+                AND `status` = #{q.status}
             </if>
             <if test="q.type != null">
                 AND type = #{q.type}
@@ -55,7 +55,7 @@
     <select id="selectByRoleId" resultMap="MenuMap">
         SELECT m.id, m.parent_id, m.title, m.router_name, m.path, m.component,
                m.type, m.perms, m.icon, m.rank, m.keep_alive, m.show_parent,
-               m.visible, m.status, m.created_at, m.updated_at, m.del_flag
+               m.visible, m.`status`, m.created_at, m.updated_at, m.del_flag
         FROM sys_menu m
                  INNER JOIN sys_role_menu rm ON rm.menu_id = m.id
         WHERE rm.role_id = #{roleId} AND m.del_flag = 0
@@ -65,7 +65,7 @@
     <select id="selectByRoleIds" resultMap="MenuMap">
         SELECT DISTINCT m.id, m.parent_id, m.title, m.router_name, m.path, m.component,
                m.type, m.perms, m.icon, m.rank, m.keep_alive, m.show_parent,
-               m.visible, m.status, m.created_at, m.updated_at, m.del_flag
+               m.visible, m.`status`, m.created_at, m.updated_at, m.del_flag
         FROM sys_menu m
                  INNER JOIN sys_role_menu rm ON rm.menu_id = m.id
         WHERE rm.role_id IN


### PR DESCRIPTION
## Summary
- normalize the permission list filter name in `PermissionController`
- ensure prefix searches append a trailing wildcard to leverage indexed lookups
- escape the `status` column in menu queries to avoid MySQL syntax errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da05b9c4588321a0bec7e77928b521