### PR TITLE
Escape reserved columns in SysMenu

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/entity/SysMenu.java
@@ -26,13 +26,14 @@ public class SysMenu {
 
     private String perms;   // 例：iam:user:list
     private String icon;
-    @TableField("rank")
+    @TableField("`rank`")
     private Integer rank;
     @TableField("keep_alive")
     private Boolean keepAlive;    // 是否开启组件缓存
     @TableField("show_parent")
     private Boolean showParent;   // 面包屑中是否显示父级
     private Integer visible; // 1显示 0隐藏
+    @TableField("`status`")
     private Integer status;  // 1启用 0禁用
 
     @JsonFormat(pattern = "yyyy-MM-dd")


### PR DESCRIPTION
## Summary
- escape the `rank` and `status` columns in the SysMenu entity so MyBatis-Plus quotes the reserved names in generated SQL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db72f063cc8321b9d51baae1607f3f