### PR TITLE
feat: support listing dictionary types

### DIFF
--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DictController.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/controller/DictController.java
@@ -19,6 +19,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * 字典控制器
  * 类型：iam:dict:type:list|create|update|delete
@@ -34,6 +36,16 @@ public class DictController {
     private final DictService dictService;
 
     /* ---------- 字典类型 ---------- */
+
+    /**
+     * 字典类型清单：支持 code/name 关键字模糊、状态与创建时间区间过滤。
+     * 若前端希望分页，可在查询层自行封装；此接口返回完整列表。
+     */
+    @GetMapping("/type")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'iam:dict:type:list')")
+    public R<List<SysDictType>> listTypes(@Valid DictTypePageQuery q) {
+        return R.ok(dictService.listTypes(q));
+    }
 
     /** 字典项分页：按 typeCode + label 模糊 */
     @GetMapping("/item/page")

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DictService.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/DictService.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.xrcgs.iam.entity.SysDictItem;
 import com.xrcgs.iam.entity.SysDictType;
 import com.xrcgs.iam.model.query.DictItemPageQuery;
+import com.xrcgs.iam.model.query.DictTypePageQuery;
 import com.xrcgs.iam.model.vo.DictVO;
 
 import java.util.List;
@@ -22,4 +23,6 @@ public interface DictService {
 
     // -------- 新增：字典项分页 --------
     Page<SysDictItem> pageItems(DictItemPageQuery q, long pageNo, long pageSize);
+
+    List<SysDictType> listTypes(DictTypePageQuery q);
 }

--- a/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DictServiceImpl.java
+++ b/xrcgs-module-iam/src/main/java/com/xrcgs/iam/service/impl/DictServiceImpl.java
@@ -1,5 +1,6 @@
 package com.xrcgs.iam.service.impl;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,12 +9,14 @@ import com.xrcgs.iam.entity.SysDictType;
 import com.xrcgs.iam.mapper.SysDictItemMapper;
 import com.xrcgs.iam.mapper.SysDictTypeMapper;
 import com.xrcgs.iam.model.query.DictItemPageQuery;
+import com.xrcgs.iam.model.query.DictTypePageQuery;
 import com.xrcgs.iam.model.vo.DictVO;
 import com.xrcgs.iam.service.DictService;
 import com.xrcgs.common.cache.AuthCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -127,5 +130,29 @@ public class DictServiceImpl implements DictService {
     public Page<SysDictItem> pageItems(DictItemPageQuery q, long pageNo, long pageSize) {
         Page<SysDictItem> page = new Page<>(pageNo, pageSize);
         return itemMapper.selectPageByQuery(page, q);
+    }
+
+    @Override
+    public List<SysDictType> listTypes(DictTypePageQuery q) {
+        LambdaQueryWrapper<SysDictType> wrapper = Wrappers.lambdaQuery();
+        if (q != null) {
+            String keyword = StringUtils.hasText(q.getKeyword()) ? q.getKeyword().trim() : null;
+            if (StringUtils.hasText(keyword)) {
+                wrapper.and(w -> w.like(SysDictType::getCode, keyword)
+                        .or()
+                        .like(SysDictType::getName, keyword));
+            }
+            if (q.getStatus() != null) {
+                wrapper.eq(SysDictType::getStatus, q.getStatus());
+            }
+            if (q.getStartTime() != null) {
+                wrapper.ge(SysDictType::getCreateTime, q.getStartTime());
+            }
+            if (q.getEndTime() != null) {
+                wrapper.le(SysDictType::getCreateTime, q.getEndTime());
+            }
+        }
+        wrapper.orderByAsc(SysDictType::getId);
+        return typeMapper.selectList(wrapper);
     }
 }


### PR DESCRIPTION
## Summary
- add a GET /api/iam/dict/type endpoint so the frontend can retrieve the dictionary type list
- implement the backing service method with optional keyword, status, and creation-time filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbdf183ce883218d1ce2133e22542d