### PR TITLE
refactor: restrict operation log external mutations

### DIFF
--- a/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/controller/SysOpLogController.java
+++ b/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/controller/SysOpLogController.java
@@ -1,0 +1,75 @@
+package com.xrcgs.syslog.controller;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.xrcgs.common.core.R;
+import com.xrcgs.syslog.annotation.OpLog;
+import com.xrcgs.syslog.entity.SysOpLog;
+import com.xrcgs.syslog.model.query.SysOpLogPageQuery;
+import com.xrcgs.syslog.service.SysOpLogService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 操作日志接口
+ */
+@Validated
+@RestController
+@RequestMapping("/api/syslog/op-log")
+@RequiredArgsConstructor
+public class SysOpLogController {
+
+    private final SysOpLogService sysOpLogService;
+
+    /**
+     * 分页查询操作日志
+     */
+    @GetMapping("/page")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'sys:op-log:list')")
+    public R<Page<SysOpLog>> page(@Valid SysOpLogPageQuery query,
+                                  @RequestParam(defaultValue = "1") long pageNo,
+                                  @RequestParam(defaultValue = "10") long pageSize) {
+        return R.ok(sysOpLogService.page(query, pageNo, pageSize));
+    }
+
+    /**
+     * 查询操作日志详情
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'sys:op-log:get')")
+    public R<SysOpLog> get(@PathVariable @NotNull Long id) {
+        return R.ok(sysOpLogService.get(id));
+    }
+
+    /**
+     * 批量删除操作日志
+     */
+    @DeleteMapping
+    @OpLog("删除操作日志")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'sys:op-log:delete')")
+    public R<Boolean> remove(@RequestBody @NotEmpty List<@NotNull Long> ids) {
+        return R.ok(sysOpLogService.deleteByIds(ids));
+    }
+
+    /**
+     * 清空所有操作日志
+     */
+    @DeleteMapping("/all")
+    @OpLog("清空操作日志")
+    @PreAuthorize("@permChecker.hasPerm(authentication, 'sys:op-log:delete')")
+    public R<Integer> clearAll() {
+        return R.ok(sysOpLogService.clearAll());
+    }
+}

--- a/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/model/query/SysOpLogPageQuery.java
+++ b/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/model/query/SysOpLogPageQuery.java
@@ -1,0 +1,24 @@
+package com.xrcgs.syslog.model.query;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 操作日志分页查询条件
+ */
+@Data
+public class SysOpLogPageQuery {
+
+    /** 标题关键字 */
+    private String title;
+
+    /** 起始请求时间 */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    /** 结束请求时间 */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endTime;
+}

--- a/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/service/SysOpLogService.java
+++ b/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/service/SysOpLogService.java
@@ -1,7 +1,20 @@
 package com.xrcgs.syslog.service;
 
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.xrcgs.syslog.entity.SysOpLog;
+import com.xrcgs.syslog.model.query.SysOpLogPageQuery;
+
+import java.util.List;
 
 public interface SysOpLogService {
+
     void saveSafe(SysOpLog log);
+
+    Page<SysOpLog> page(SysOpLogPageQuery query, long pageNo, long pageSize);
+
+    SysOpLog get(Long id);
+
+    boolean deleteByIds(List<Long> ids);
+
+    int clearAll();
 }

--- a/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/service/impl/SysOpLogServiceImpl.java
+++ b/xrcgs-module-syslog/src/main/java/com/xrcgs/syslog/service/impl/SysOpLogServiceImpl.java
@@ -1,11 +1,21 @@
 package com.xrcgs.syslog.service.impl;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.xrcgs.syslog.entity.SysOpLog;
 import com.xrcgs.syslog.mapper.SysOpLogMapper;
+import com.xrcgs.syslog.model.query.SysOpLogPageQuery;
 import com.xrcgs.syslog.service.SysOpLogService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,5 +32,55 @@ public class SysOpLogServiceImpl implements SysOpLogService {
             log.warn("sys_op_log insert failed. payload(title={}, uri={}, user={})",
                     opLog.getTitle(), opLog.getUri(), opLog.getUsername(), e);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SysOpLog> page(SysOpLogPageQuery query, long pageNo, long pageSize) {
+        SysOpLogPageQuery actualQuery = query == null ? new SysOpLogPageQuery() : query;
+        LambdaQueryWrapper<SysOpLog> wrapper = Wrappers.lambdaQuery();
+
+        if (StringUtils.hasText(actualQuery.getTitle())) {
+            wrapper.like(SysOpLog::getTitle, actualQuery.getTitle());
+        }
+
+        LocalDateTime start = actualQuery.getStartTime();
+        LocalDateTime end = actualQuery.getEndTime();
+        if (start != null && end != null && end.isBefore(start)) {
+            LocalDateTime tmp = start;
+            start = end;
+            end = tmp;
+        }
+        if (start != null) {
+            wrapper.ge(SysOpLog::getCreatedAt, start);
+        }
+        if (end != null) {
+            wrapper.le(SysOpLog::getCreatedAt, end);
+        }
+
+        wrapper.orderByDesc(SysOpLog::getCreatedAt);
+        Page<SysOpLog> page = Page.of(pageNo, pageSize);
+        return mapper.selectPage(page, wrapper);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SysOpLog get(Long id) {
+        return mapper.selectById(id);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public boolean deleteByIds(List<Long> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return false;
+        }
+        return mapper.deleteBatchIds(ids) > 0;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int clearAll() {
+        return mapper.delete(Wrappers.lambdaQuery());
     }
 }


### PR DESCRIPTION
## Summary
- remove the operation log create and update endpoints to prevent external modification of log records
- drop the related request DTOs and service methods now that external mutation is no longer supported

## Testing
- mvn -pl xrcgs-module-syslog test *(fails: Could not find artifact com.xrcgs:xrcgs-common:jar:1.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68e08abc604083219c3077e85f8f1065