### PR TITLE
chore: refine road safety module setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>xrcgs-module-syslog</module>
         <module>xrcgs-module-file</module>
         <module>xrcgs-module-workflow</module>
+        <module>xrcgs-module-road-safety</module>
     </modules>
 
     <build>

--- a/xrcgs-module-road-safety/pom.xml
+++ b/xrcgs-module-road-safety/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.xrcgs</groupId>
+        <artifactId>xrcgs-admin</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xrcgs-module-road-safety</artifactId>
+    <name>xrcgs-module-road-safety</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <poi.version>5.2.5</poi.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring 基础能力 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- MyBatis-Plus -->
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+            <version>${mybatis-plus.version}</version>
+        </dependency>
+
+        <!-- Lombok (可选) -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- 公共能力及基础设施模块 -->
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-infrastructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-module-syslog</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-module-iam</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-module-file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- 数据库与文档处理能力 -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>${poi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${poi.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyModuleConfiguration.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyModuleConfiguration.java
@@ -1,0 +1,12 @@
+package com.xrcgs.roadsafety.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 基础配置入口，提供路产安全模块的组件扫描能力。
+ */
+@Configuration
+@ComponentScan(basePackages = "com.xrcgs.roadsafety")
+public class RoadSafetyModuleConfiguration {
+}


### PR DESCRIPTION
## Summary
- register the new road safety module in the parent build
- remove the placeholder road safety task scaffolding so the module can be redesigned from scratch
- add MySQL 8, Apache POI, and file module dependencies to the road safety module

## Testing
- mvn -pl xrcgs-module-road-safety -am test

------
https://chatgpt.com/codex/tasks/task_e_68e1deeb3188832199c4547b5dc87e7b