### PR TITLE
refactor: externalize road safety inspection template

### DIFF
--- a/xrcgs-module-road-safety/pom.xml
+++ b/xrcgs-module-road-safety/pom.xml
@@ -88,5 +88,11 @@
             <artifactId>poi-ooxml</artifactId>
             <version>${poi.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
@@ -1,0 +1,397 @@
+package com.xrcgs.roadsafety.inspection.application.service;
+
+import com.xrcgs.roadsafety.inspection.domain.model.HandlingCategoryGroup;
+import com.xrcgs.roadsafety.inspection.domain.model.InspectionRecord;
+import com.xrcgs.roadsafety.inspection.domain.model.PhotoItem;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.util.Units;
+import org.apache.poi.xssf.usermodel.XSSFDrawing;
+import org.apache.poi.xssf.usermodel.XSSFPicture;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.ss.usermodel.CellCopyPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 基于巡查记录模板的 Excel 导出能力，负责将结构化巡查数据写入模板并生成正式文档。
+ */
+@Service
+public class InspectionRecordExcelExporter {
+
+    private static final Logger log = LoggerFactory.getLogger(InspectionRecordExcelExporter.class);
+
+    private static final String TEMPLATE_CLASSPATH = "excel/inspectionRecord.xlsx";
+    private static final String DEFAULT_EXPORT_NAME = "inspection_record_output.xlsx";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy年MM月dd日");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy年MM月dd日 HH:mm");
+    private static final int PHOTOS_PER_PAGE = 2;
+    private static final int THIRD_PAGE_START_ROW = 65;
+    private static final int THIRD_PAGE_END_ROW = 114;
+    private static final int ROWS_PER_ADDITIONAL_PAGE = THIRD_PAGE_END_ROW - THIRD_PAGE_START_ROW + 1;
+
+    private static final List<PhotoSlotTemplate> BASE_PHOTO_SLOTS = List.of(
+            new PhotoSlotTemplate(1, 14, 4, 38, 39, 39, 2),
+            new PhotoSlotTemplate(1, 40, 4, 63, 64, 64, 2),
+            new PhotoSlotTemplate(1, 66, 4, 87, 88, 90, 2),
+            new PhotoSlotTemplate(1, 91, 4, 111, 112, 114, 2)
+    );
+
+    private static final List<PhotoSlotTemplate> ADDITIONAL_PAGE_SLOTS = List.of(
+            new PhotoSlotTemplate(1, 66, 4, 87, 88, 90, 2),
+            new PhotoSlotTemplate(1, 91, 4, 111, 112, 114, 2)
+    );
+
+    // 注入模板资源，便于在不同运行环境或测试中覆盖默认模板。
+    private final Resource templateResource;
+
+    public InspectionRecordExcelExporter() {
+        this(new ClassPathResource(TEMPLATE_CLASSPATH));
+    }
+
+    InspectionRecordExcelExporter(Resource templateResource) {
+        this.templateResource = templateResource;
+    }
+
+    /**
+     * 使用系统临时目录作为导出位置。
+     */
+    public Path export(InspectionRecord record) throws IOException {
+        return export(record, Paths.get(System.getProperty("java.io.tmpdir")));
+    }
+
+    /**
+     * 按照模板将巡查记录导出为 Excel 文件。
+     *
+     * @param record         巡查记录数据
+     * @param outputDirectory 导出目录
+     * @return 生成文件的路径
+     */
+    public Path export(InspectionRecord record, Path outputDirectory) throws IOException {
+        Objects.requireNonNull(record, "inspection record must not be null");
+        if (outputDirectory == null) {
+            outputDirectory = Paths.get(System.getProperty("java.io.tmpdir"));
+        }
+        Files.createDirectories(outputDirectory);
+
+        try (InputStream templateStream = openTemplate();
+             Workbook workbook = WorkbookFactory.create(templateStream)) {
+            XSSFSheet sheet = (XSSFSheet) workbook.getSheetAt(0);
+
+            // 逐段将巡查信息写入到模板对应区域，保持原有样式与格式。
+            fillHeaderInfo(sheet, record);
+            fillHandlingSection(sheet, record);
+            fillRemarks(sheet, record);
+            writePhotos(workbook, sheet, Optional.ofNullable(record.getPhotos()).orElse(Collections.emptyList()));
+
+            Path exportPath = outputDirectory.resolve(determineFileName(record));
+            try (OutputStream outputStream = Files.newOutputStream(exportPath)) {
+                workbook.write(outputStream);
+            }
+            return exportPath;
+        }
+    }
+
+    private InputStream openTemplate() throws IOException {
+        if (!templateResource.exists()) {
+            throw new IOException("巡查记录模板不存在: " + templateResource.getDescription());
+        }
+        return templateResource.getInputStream();
+    }
+
+    private void fillHeaderInfo(Sheet sheet, InspectionRecord record) {
+        setCellToRightOfLabel(sheet, "巡查时间", formatDate(record.getDate()));
+        setCellToRightOfLabel(sheet, "天气情况", defaultText(record.getWeather()));
+        setCellToRightOfLabel(sheet, "巡查人员", defaultText(record.getPatrolTeam()));
+        // 模板中存在“巡查车辆”字段，当前未提供专门字段，保持空白即可。
+        setCellToRightOfLabel(sheet, "巡查里程", defaultText(record.getLocation()));
+        setCellToRightOfLabel(sheet, "巡查路段", defaultText(record.getLocation()));
+    }
+
+    private void fillHandlingSection(Sheet sheet, InspectionRecord record) {
+        // 构建巡查概述+处理情况的正文，按模板顺序组织段落。
+        StringBuilder builder = new StringBuilder();
+        builder.append("巡查内容：").append(defaultText(record.getInspectionContent())).append(System.lineSeparator());
+        builder.append("发现的问题：").append(defaultText(record.getIssuesFound())).append(System.lineSeparator());
+        builder.append("处理情况（原始记录）：").append(defaultText(record.getHandlingSituationRaw())).append(System.lineSeparator());
+        builder.append("处理情况（分类汇总）：").append(System.lineSeparator());
+        builder.append(buildHandlingDetails(record.getHandlingDetails()));
+        setCellToRightOfLabel(sheet, "巡查、处理情况", builder.toString().trim());
+    }
+
+    private void fillRemarks(Sheet sheet, InspectionRecord record) {
+        String remark = buildRemark(record);
+        if (StringUtils.hasText(remark)) {
+            setCellToRightOfLabel(sheet, "备注", remark);
+        }
+    }
+
+    private String buildRemark(InspectionRecord record) {
+        List<String> lines = new ArrayList<>();
+        if (StringUtils.hasText(record.getCreatedBy()) || record.getCreatedAt() != null) {
+            lines.add("创建：" + buildNameWithTime(record.getCreatedBy(), record.getCreatedAt()));
+        }
+        if (record.getUpdatedAt() != null) {
+            lines.add("最后更新时间：" + DATE_TIME_FORMATTER.format(record.getUpdatedAt()));
+        }
+        if (StringUtils.hasText(record.getExportedBy()) || record.getExportedAt() != null) {
+            lines.add("导出：" + buildNameWithTime(record.getExportedBy(), record.getExportedAt()));
+        }
+        if (StringUtils.hasText(record.getExportFileName())) {
+            lines.add("导出文件：" + ensureExcelExtension(record.getExportFileName()));
+        }
+        return lines.isEmpty() ? "" : String.join(System.lineSeparator(), lines);
+    }
+
+    private String buildNameWithTime(String name, LocalDateTime time) {
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.hasText(name)) {
+            builder.append(name.trim());
+        }
+        if (time != null) {
+            if (builder.length() > 0) {
+                builder.append(" ");
+            }
+            builder.append("(").append(DATE_TIME_FORMATTER.format(time)).append(")");
+        }
+        return builder.length() == 0 ? "无" : builder.toString();
+    }
+
+    private void writePhotos(Workbook workbook, XSSFSheet sheet, List<PhotoItem> photos) throws IOException {
+        if (photos.isEmpty()) {
+            return;
+        }
+        // 根据照片数量动态准备插槽（复制模板页、计算坐标等）。
+        List<PhotoSlotTemplate> slots = preparePhotoSlots(sheet, photos.size());
+        CreationHelper helper = workbook.getCreationHelper();
+        XSSFDrawing drawing = sheet.createDrawingPatriarch();
+
+        for (int i = 0; i < photos.size(); i++) {
+            PhotoItem photo = photos.get(i);
+            if (photo == null || !StringUtils.hasText(photo.getImagePath())) {
+                continue;
+            }
+            PhotoSlotTemplate slot = slots.get(i);
+            insertPhoto(workbook, helper, drawing, sheet, slot, photo);
+        }
+    }
+
+    private List<PhotoSlotTemplate> preparePhotoSlots(XSSFSheet sheet, int photoCount) {
+        List<PhotoSlotTemplate> slots = new ArrayList<>(BASE_PHOTO_SLOTS);
+        if (photoCount <= BASE_PHOTO_SLOTS.size()) {
+            return slots;
+        }
+        int additionalPhotos = photoCount - BASE_PHOTO_SLOTS.size();
+        int additionalPages = (int) Math.ceil(additionalPhotos / (double) PHOTOS_PER_PAGE);
+
+        int baseStart = THIRD_PAGE_START_ROW - 1;
+        int baseEnd = THIRD_PAGE_END_ROW - 1;
+        int insertPosition = baseEnd + 1;
+        for (int i = 0; i < additionalPages; i++) {
+            // 模板第三页作为扩展页模板，逐页复制后计算新的照片、说明单元格位置。
+            sheet.copyRows(baseStart, baseEnd, insertPosition, new CellCopyPolicy());
+            int rowShift = ROWS_PER_ADDITIONAL_PAGE * (i + 1);
+            for (PhotoSlotTemplate template : ADDITIONAL_PAGE_SLOTS) {
+                slots.add(template.shift(rowShift));
+            }
+            insertPosition += ROWS_PER_ADDITIONAL_PAGE;
+        }
+        return slots;
+    }
+
+    private void insertPhoto(Workbook workbook, CreationHelper helper, XSSFDrawing drawing, XSSFSheet sheet,
+                              PhotoSlotTemplate slot, PhotoItem photo) throws IOException {
+        Path imagePath = Paths.get(photo.getImagePath());
+        if (!Files.exists(imagePath)) {
+            throw new IOException("巡查照片不存在：" + imagePath);
+        }
+        byte[] imageBytes = Files.readAllBytes(imagePath);
+        int pictureType = resolvePictureType(imagePath.getFileName().toString());
+        int pictureIndex = workbook.addPicture(imageBytes, pictureType);
+
+        ClientAnchor anchor = helper.createClientAnchor();
+        anchor.setCol1(slot.col1() - 1);
+        anchor.setRow1(slot.row1() - 1);
+        anchor.setCol2(slot.col2());
+        anchor.setRow2(slot.row2());
+        anchor.setDx1(Units.toEMU(10));
+        anchor.setDy1(Units.toEMU(10));
+        anchor.setDx2(Units.toEMU(10));
+        anchor.setDy2(Units.toEMU(10));
+        anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
+
+        XSSFPicture picture = drawing.createPicture(anchor, pictureIndex);
+
+        // 图片说明单独写入模板预留的文字区域。
+        writePhotoDescription(sheet, slot, defaultText(photo.getDescription()));
+    }
+
+    private void writePhotoDescription(Sheet sheet, PhotoSlotTemplate slot, String description) {
+        Row row = sheet.getRow(slot.descRowStart() - 1);
+        if (row == null) {
+            row = sheet.createRow(slot.descRowStart() - 1);
+        }
+        Cell cell = row.getCell(slot.descColumn() - 1, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+        cell.setCellValue(description);
+        for (int r = slot.descRowStart(); r <= slot.descRowEnd(); r++) {
+            if (r == slot.descRowStart()) {
+                continue;
+            }
+            Row extraRow = sheet.getRow(r - 1);
+            if (extraRow == null) {
+                extraRow = sheet.createRow(r - 1);
+            }
+            Cell extraCell = extraRow.getCell(slot.descColumn() - 1, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            if (StringUtils.hasText(extraCell.getStringCellValue())) {
+                extraCell.setCellValue("");
+            }
+        }
+    }
+
+    private void setCellToRightOfLabel(Sheet sheet, String label, String value) {
+        findCellByLabel(sheet, label).ifPresent(labelCell -> {
+            Row row = sheet.getRow(labelCell.getRowIndex());
+            if (row == null) {
+                return;
+            }
+            Cell target = row.getCell(labelCell.getColumnIndex() + 1, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            target.setCellValue(Optional.ofNullable(value).orElse(""));
+        });
+    }
+
+    private Optional<Cell> findCellByLabel(Sheet sheet, String label) {
+        for (Row row : sheet) {
+            for (Cell cell : row) {
+                if (cell != null && cell.getCellType() == CellType.STRING) {
+                    String text = cell.getStringCellValue();
+                    if (text != null && text.contains(label)) {
+                        return Optional.of(cell);
+                    }
+                }
+            }
+        }
+        log.debug("未在模板中找到标签：{}", label);
+        return Optional.empty();
+    }
+
+    private String buildHandlingDetails(HandlingCategoryGroup group) {
+        HandlingCategoryGroup effective = Optional.ofNullable(group).orElseGet(HandlingCategoryGroup::new);
+        StringBuilder sb = new StringBuilder();
+        // 分类段落顺序遵循业务要求，保持与模板一致。
+        appendCategory(sb, "一、道路病害或损坏情况", effective.getRoadDamage());
+        appendCompositeCategory(sb, "二、交通事故或清障救援情况",
+                new SubCategory("（交通事故）", effective.getTrafficAccidents()),
+                new SubCategory("（清障救援）", effective.getRoadRescue()));
+        appendCategory(sb, "三、设施赔补偿情况", effective.getFacilityCompensations());
+        appendCompositeCategory(sb, "四、大件或超限车辆检查",
+                new SubCategory("（大件检查）", effective.getLargeVehicleChecks()),
+                new SubCategory("（超限车辆处理）", effective.getOverloadVehicleHandling()));
+        appendCategory(sb, "五、涉路施工检查", effective.getConstructionChecks());
+        appendCategory(sb, "六、违法侵权事件", effective.getIllegalInfringements());
+        appendCategory(sb, "七、其他情况", effective.getOtherMatters());
+        return sb.toString().trim();
+    }
+
+    private void appendCategory(StringBuilder sb, String header, List<String> items) {
+        if (sb.length() > 0) {
+            sb.append(System.lineSeparator());
+        }
+        sb.append(header).append(System.lineSeparator());
+        writeItems(sb, items);
+    }
+
+    private void appendCompositeCategory(StringBuilder sb, String header, SubCategory... subCategories) {
+        if (sb.length() > 0) {
+            sb.append(System.lineSeparator());
+        }
+        sb.append(header).append(System.lineSeparator());
+        for (SubCategory sub : subCategories) {
+            sb.append(sub.title()).append(System.lineSeparator());
+            writeItems(sb, sub.items());
+        }
+    }
+
+    private void writeItems(StringBuilder sb, List<String> items) {
+        List<String> normalized = Optional.ofNullable(items).orElseGet(Collections::emptyList)
+                .stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .toList();
+        if (normalized.isEmpty()) {
+            sb.append("无").append(System.lineSeparator());
+        } else {
+            normalized.forEach(item -> sb.append("- ").append(item).append(System.lineSeparator()));
+        }
+    }
+
+    private String defaultText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : "无";
+    }
+
+    private String formatDate(LocalDate date) {
+        return date == null ? "" : DATE_FORMATTER.format(date);
+    }
+
+    private String ensureExcelExtension(String fileName) {
+        String trimmed = fileName.trim();
+        return trimmed.toLowerCase(Locale.ROOT).endsWith(".xlsx") ? trimmed : trimmed + ".xlsx";
+    }
+
+    private int resolvePictureType(String fileName) {
+        String lowerName = fileName.toLowerCase(Locale.ROOT);
+        if (lowerName.endsWith(".png")) {
+            return Workbook.PICTURE_TYPE_PNG;
+        }
+        if (lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg")) {
+            return Workbook.PICTURE_TYPE_JPEG;
+        }
+        if (lowerName.endsWith(".bmp")) {
+            return Workbook.PICTURE_TYPE_DIB;
+        }
+        throw new IllegalArgumentException("不支持的图片格式：" + fileName);
+    }
+
+    private String determineFileName(InspectionRecord record) {
+        String fileName = record.getExportFileName();
+        if (!StringUtils.hasText(fileName)) {
+            return DEFAULT_EXPORT_NAME;
+        }
+        return ensureExcelExtension(fileName);
+    }
+
+    private record PhotoSlotTemplate(int col1, int row1, int col2, int row2,
+                                     int descRowStart, int descRowEnd, int descColumn) {
+        PhotoSlotTemplate shift(int rowShift) {
+            return new PhotoSlotTemplate(col1, row1 + rowShift, col2, row2 + rowShift,
+                    descRowStart + rowShift, descRowEnd + rowShift, descColumn);
+        }
+    }
+
+    private record SubCategory(String title, List<String> items) {
+    }
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/HandlingCategoryGroup.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/HandlingCategoryGroup.java
@@ -1,0 +1,46 @@
+package com.xrcgs.roadsafety.inspection.domain.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 巡查处理情况的分类结构，支持将原始文本内容拆分为不同的业务分类，方便后续格式化输出。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HandlingCategoryGroup {
+
+    @Builder.Default
+    private List<String> roadDamage = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> trafficAccidents = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> roadRescue = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> facilityCompensations = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> largeVehicleChecks = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> overloadVehicleHandling = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> constructionChecks = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> illegalInfringements = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> otherMatters = new ArrayList<>();
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/InspectionRecord.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/InspectionRecord.java
@@ -1,0 +1,82 @@
+package com.xrcgs.roadsafety.inspection.domain.model;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 路产安全巡查记录的核心实体，包含基础信息、处理情况以及照片等要素。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InspectionRecord {
+
+    private Long id;
+
+    /**
+     * 巡查日期。
+     */
+    private LocalDate date;
+
+    /**
+     * 天气情况。
+     */
+    private String weather;
+
+    /**
+     * 巡查人员或班组。
+     */
+    private String patrolTeam;
+
+    /**
+     * 巡查路线、里程与桩号。
+     */
+    private String location;
+
+    /**
+     * 巡查内容概述。
+     */
+    private String inspectionContent;
+
+    /**
+     * 巡查中发现的问题描述。
+     */
+    private String issuesFound;
+
+    /**
+     * 原始填写的处理情况文字。
+     */
+    private String handlingSituationRaw;
+
+    /**
+     * 结构化的处理情况分类。
+     */
+    @Builder.Default
+    private HandlingCategoryGroup handlingDetails = new HandlingCategoryGroup();
+
+    /**
+     * 照片集合。
+     */
+    @Builder.Default
+    private List<PhotoItem> photos = new ArrayList<>();
+
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private String exportedBy;
+    private LocalDateTime exportedAt;
+
+    /**
+     * 导出文件名，若为空则使用默认名称。
+     */
+    private String exportFileName;
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/PhotoItem.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/PhotoItem.java
@@ -1,0 +1,26 @@
+package com.xrcgs.roadsafety.inspection.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 巡查照片信息，包含文件路径以及对应说明。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoItem {
+
+    /**
+     * 图片所在的本地路径或网络下载后的缓存路径。
+     */
+    private String imagePath;
+
+    /**
+     * 对应的文字说明，写入在图片下方。
+     */
+    private String description;
+}

--- a/xrcgs-module-road-safety/src/test/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporterTest.java
+++ b/xrcgs-module-road-safety/src/test/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporterTest.java
@@ -1,0 +1,161 @@
+package com.xrcgs.roadsafety.inspection.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.xrcgs.roadsafety.inspection.domain.model.HandlingCategoryGroup;
+import com.xrcgs.roadsafety.inspection.domain.model.InspectionRecord;
+import com.xrcgs.roadsafety.inspection.domain.model.PhotoItem;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * 巡查记录 Excel 导出能力的集成测试，验证写入文本与分页照片能力。
+ */
+class InspectionRecordExcelExporterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldExportInspectionRecordWithPhotosAndHandlingDetails() throws Exception {
+        Path template = createTemplateWorkbook(tempDir.resolve("excel/inspectionRecord.xlsx"));
+        InspectionRecordExcelExporter exporter = new InspectionRecordExcelExporter(new FileSystemResource(template));
+        Path photoDir = Files.createDirectories(tempDir.resolve("photos"));
+        List<PhotoItem> photos = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            Path image = createSampleImage(photoDir.resolve("photo-" + i + ".jpg"), "照片" + i);
+            photos.add(PhotoItem.builder().imagePath(image.toString()).description("第" + i + "张照片").build());
+        }
+
+        HandlingCategoryGroup categoryGroup = HandlingCategoryGroup.builder()
+                .roadDamage(List.of("路面沉陷处设置警示标志。"))
+                .roadRescue(List.of("拖移故障车辆1辆。"))
+                .largeVehicleChecks(List.of("检查大件运输车辆2辆，手续齐全。"))
+                .overloadVehicleHandling(List.of("劝返超限车辆1辆。"))
+                .otherMatters(List.of("与交警联合巡查。"))
+                .build();
+
+        InspectionRecord record = InspectionRecord.builder()
+                .id(1L)
+                .date(LocalDate.of(2024, 12, 1))
+                .weather("晴")
+                .patrolTeam("巡查一队")
+                .location("K10+000-K20+000")
+                .inspectionContent("路面、桥涵专项巡查。")
+                .issuesFound("发现1处沉陷。")
+                .handlingSituationRaw("现场设置警戒并安排抢修。")
+                .handlingDetails(categoryGroup)
+                .photos(photos)
+                .createdBy("张三")
+                .createdAt(LocalDateTime.of(2024, 12, 1, 9, 30))
+                .updatedAt(LocalDateTime.of(2024, 12, 1, 18, 0))
+                .exportedBy("李四")
+                .exportedAt(LocalDateTime.of(2024, 12, 1, 18, 30))
+                .exportFileName("record.xlsx")
+                .build();
+
+        Path output = exporter.export(record, tempDir);
+        assertThat(Files.exists(output)).isTrue();
+
+        try (InputStream inputStream = Files.newInputStream(output);
+             Workbook workbook = WorkbookFactory.create(inputStream)) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            String dateText = readValueRightOfLabel(sheet, "巡查时间");
+            assertThat(dateText).contains("2024年12月01日");
+
+            String handlingText = readValueRightOfLabel(sheet, "巡查、处理情况");
+            assertThat(handlingText)
+                    .contains("一、道路病害或损坏情况")
+                    .contains("路面沉陷处设置警示标志")
+                    .contains("二、交通事故或清障救援情况")
+                    .contains("（清障救援）")
+                    .contains("拖移故障车辆1辆")
+                    .contains("七、其他情况");
+
+            String remarkText = readValueRightOfLabel(sheet, "备注");
+            assertThat(remarkText).contains("创建：张三 (2024年12月01日 09:30)");
+            assertThat(remarkText).contains("导出：李四 (2024年12月01日 18:30)");
+
+            boolean foundFifthDescription = false;
+            for (Row row : sheet) {
+                Cell cell = row.getCell(1);
+                if (cell != null && "第5张照片".equals(cell.getStringCellValue())) {
+                    assertThat(row.getRowNum()).isGreaterThanOrEqualTo(114);
+                    foundFifthDescription = true;
+                    break;
+                }
+            }
+            assertThat(foundFifthDescription).isTrue();
+        }
+    }
+
+    private Path createSampleImage(Path path, String text) throws IOException {
+        BufferedImage image = new BufferedImage(600, 400, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+        graphics.setColor(Color.BLACK);
+        graphics.drawString(text, 40, image.getHeight() / 2);
+        graphics.dispose();
+        javax.imageio.ImageIO.write(image, "jpg", path.toFile());
+        return path;
+    }
+
+    /**
+     * 构造一个满足导出逻辑的最小化模板，避免在仓库中提交真实业务模板。
+     */
+    private Path createTemplateWorkbook(Path path) throws IOException {
+        Files.createDirectories(path.getParent());
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("模板");
+            for (int i = 0; i <= 150; i++) {
+                sheet.createRow(i);
+            }
+            sheet.getRow(2).createCell(0).setCellValue("巡查时间");
+            sheet.getRow(3).createCell(0).setCellValue("天气情况");
+            sheet.getRow(4).createCell(0).setCellValue("巡查人员");
+            sheet.getRow(5).createCell(0).setCellValue("巡查里程");
+            sheet.getRow(6).createCell(0).setCellValue("巡查路段");
+            sheet.getRow(7).createCell(0).setCellValue("巡查、处理情况");
+            sheet.getRow(11).createCell(0).setCellValue("备注");
+
+            try (OutputStream outputStream = Files.newOutputStream(path)) {
+                workbook.write(outputStream);
+            }
+        }
+        return path;
+    }
+
+    private String readValueRightOfLabel(Sheet sheet, String label) {
+        for (Row row : sheet) {
+            for (Cell cell : row) {
+                if (cell.getCellType() == CellType.STRING && cell.getStringCellValue().contains(label)) {
+                    return row.getCell(cell.getColumnIndex() + 1, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK)
+                            .getStringCellValue();
+                }
+            }
+        }
+        throw new IllegalStateException("未找到标签: " + label);
+    }
+}


### PR DESCRIPTION
## Summary
- remove the committed inspection record template and allow the exporter to work with an injected resource
- add explanatory comments around key export steps for easier maintenance
- build a minimal Excel template during tests to validate handling and photo pagination without bundling the real asset

## Testing
- mvn -pl xrcgs-module-road-safety -am test

------
https://chatgpt.com/codex/tasks/task_e_68e1ecca52408321a7359b61dae7e430