### PR TITLE
feat: enhance inspection record excel export with photo paging

### DIFF
--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
@@ -3,21 +3,26 @@ package com.xrcgs.roadsafety.inspection.application.service;
 import com.xrcgs.roadsafety.inspection.domain.model.HandlingCategoryGroup;
 import com.xrcgs.roadsafety.inspection.domain.model.InspectionRecord;
 import com.xrcgs.roadsafety.inspection.domain.model.PhotoItem;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.InvalidPathException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import javax.imageio.ImageIO;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.ClientAnchor;
@@ -27,11 +32,11 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.util.Units;
+import org.apache.poi.ss.util.SheetUtil;
 import org.apache.poi.xssf.usermodel.XSSFDrawing;
-import org.apache.poi.xssf.usermodel.XSSFPicture;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
-import org.apache.poi.ss.usermodel.CellCopyPolicy;
-import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
+import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -47,25 +52,18 @@ public class InspectionRecordExcelExporter {
 
     private static final Logger log = LoggerFactory.getLogger(InspectionRecordExcelExporter.class);
 
-    private static final String TEMPLATE_CLASSPATH = "excel/inspectionRecord.xlsx";
+    private static final String TEMPLATE_CLASSPATH = "excel/inspection_record.xlsx";
     private static final String DEFAULT_EXPORT_NAME = "inspection_record_output.xlsx";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy年MM月dd日");
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy年MM月dd日 HH:mm");
     private static final int PHOTOS_PER_PAGE = 2;
-    private static final int THIRD_PAGE_START_ROW = 65;
-    private static final int THIRD_PAGE_END_ROW = 114;
-    private static final int ROWS_PER_ADDITIONAL_PAGE = THIRD_PAGE_END_ROW - THIRD_PAGE_START_ROW + 1;
+    private static final double PHOTO_MARGIN_POINTS = 2.0;
+    private static final long EMU_PER_PIXEL = 9525L;
+    private static final long EMU_PER_POINT = 12700L;
 
-    private static final List<PhotoSlotTemplate> BASE_PHOTO_SLOTS = List.of(
-            new PhotoSlotTemplate(1, 14, 4, 38, 39, 39, 2),
-            new PhotoSlotTemplate(1, 40, 4, 63, 64, 64, 2),
-            new PhotoSlotTemplate(1, 66, 4, 87, 88, 90, 2),
-            new PhotoSlotTemplate(1, 91, 4, 111, 112, 114, 2)
-    );
-
-    private static final List<PhotoSlotTemplate> ADDITIONAL_PAGE_SLOTS = List.of(
-            new PhotoSlotTemplate(1, 66, 4, 87, 88, 90, 2),
-            new PhotoSlotTemplate(1, 91, 4, 111, 112, 114, 2)
+    private static final List<PhotoSlotTemplate> PAGE_PHOTO_SLOTS = List.of(
+            new PhotoSlotTemplate(1, 2, 4, 26, 27, 27, 1),
+            new PhotoSlotTemplate(1, 28, 4, 51, 52, 52, 1)
     );
 
     // 注入模板资源，便于在不同运行环境或测试中覆盖默认模板。
@@ -101,14 +99,16 @@ public class InspectionRecordExcelExporter {
         Files.createDirectories(outputDirectory);
 
         try (InputStream templateStream = openTemplate();
-             Workbook workbook = WorkbookFactory.create(templateStream)) {
-            XSSFSheet sheet = (XSSFSheet) workbook.getSheetAt(0);
+             Workbook workbookDelegate = WorkbookFactory.create(templateStream)) {
+            XSSFWorkbook workbook = (XSSFWorkbook) workbookDelegate;
+            XSSFSheet infoSheet = workbook.getSheetAt(0);
 
             // 逐段将巡查信息写入到模板对应区域，保持原有样式与格式。
-            fillHeaderInfo(sheet, record);
-            fillHandlingSection(sheet, record);
-            fillRemarks(sheet, record);
-            writePhotos(workbook, sheet, Optional.ofNullable(record.getPhotos()).orElse(Collections.emptyList()));
+            fillHeaderInfo(infoSheet, record);
+            fillHandlingSection(infoSheet, record);
+            fillRemarks(infoSheet, record);
+            fillAuditTrail(infoSheet, record);
+            writePhotos(workbook, Optional.ofNullable(record.getPhotos()).orElse(Collections.emptyList()));
 
             Path exportPath = outputDirectory.resolve(determineFileName(record));
             try (OutputStream outputStream = Files.newOutputStream(exportPath)) {
@@ -125,24 +125,44 @@ public class InspectionRecordExcelExporter {
         return templateResource.getInputStream();
     }
 
-    private void fillHeaderInfo(Sheet sheet, InspectionRecord record) {
+    private void fillHeaderInfo(XSSFSheet sheet, InspectionRecord record) {
+        adjustRowHeight(sheet, 0, 29.25f);
+        adjustRowHeight(sheet, 1, 25f);
+        for (int i = 2; i <= 5; i++) {
+            adjustRowHeight(sheet, i, 28f);
+        }
+
+        setCellValue(sheet, 0, 0, "巡查记录表");
+        setCellValue(sheet, 1, 0, "单位：" + defaultText(record.getUnitName()));
+
         setCellToRightOfLabel(sheet, "巡查时间", formatDate(record.getDate()));
         setCellToRightOfLabel(sheet, "天气情况", defaultText(record.getWeather()));
         setCellToRightOfLabel(sheet, "巡查人员", defaultText(record.getPatrolTeam()));
-        // 模板中存在“巡查车辆”字段，当前未提供专门字段，保持空白即可。
         setCellToRightOfLabel(sheet, "巡查里程", defaultText(record.getLocation()));
         setCellToRightOfLabel(sheet, "巡查路段", defaultText(record.getLocation()));
+    }
+
+    private void setCellValue(XSSFSheet sheet, int rowIndex, int columnIndex, String value) {
+        XSSFRow row = Optional.ofNullable(sheet.getRow(rowIndex)).orElseGet(() -> sheet.createRow(rowIndex));
+        row.setZeroHeight(false);
+        Cell cell = row.getCell(columnIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+        cell.setCellValue(Optional.ofNullable(value).orElse(""));
+    }
+
+    private void adjustRowHeight(XSSFSheet sheet, int rowIndex, float height) {
+        XSSFRow row = Optional.ofNullable(sheet.getRow(rowIndex)).orElseGet(() -> sheet.createRow(rowIndex));
+        row.setHeightInPoints(height);
     }
 
     private void fillHandlingSection(Sheet sheet, InspectionRecord record) {
         // 构建巡查概述+处理情况的正文，按模板顺序组织段落。
         StringBuilder builder = new StringBuilder();
         builder.append("巡查内容：").append(defaultText(record.getInspectionContent())).append(System.lineSeparator());
-        builder.append("发现的问题：").append(defaultText(record.getIssuesFound())).append(System.lineSeparator());
+        builder.append("问题描述：").append(defaultText(record.getIssuesFound())).append(System.lineSeparator());
         builder.append("处理情况（原始记录）：").append(defaultText(record.getHandlingSituationRaw())).append(System.lineSeparator());
         builder.append("处理情况（分类汇总）：").append(System.lineSeparator());
         builder.append(buildHandlingDetails(record.getHandlingDetails()));
-        setCellToRightOfLabel(sheet, "巡查、处理情况", builder.toString().trim());
+        setCellToRightOfLabel(sheet, "巡查、处理情况", builder.toString().stripTrailing());
     }
 
     private void fillRemarks(Sheet sheet, InspectionRecord record) {
@@ -150,6 +170,38 @@ public class InspectionRecordExcelExporter {
         if (StringUtils.hasText(remark)) {
             setCellToRightOfLabel(sheet, "备注", remark);
         }
+    }
+
+    private void fillAuditTrail(XSSFSheet sheet, InspectionRecord record) {
+        int startRowIndex = Math.max(sheet.getLastRowNum() + 2, 30);
+        XSSFRow keyRow = Optional.ofNullable(sheet.getRow(startRowIndex)).orElseGet(() -> sheet.createRow(startRowIndex));
+        XSSFRow valueRow = Optional.ofNullable(sheet.getRow(startRowIndex + 1)).orElseGet(() -> sheet.createRow(startRowIndex + 1));
+        keyRow.setZeroHeight(true);
+        valueRow.setZeroHeight(true);
+
+        writeAuditCell(keyRow, 0, "createdBy");
+        writeAuditCell(valueRow, 0, normalizeAuditValue(record.getCreatedBy()));
+
+        writeAuditCell(keyRow, 1, "createdAt");
+        writeAuditCell(valueRow, 1, formatDateTime(record.getCreatedAt()));
+
+        writeAuditCell(keyRow, 2, "updatedAt");
+        writeAuditCell(valueRow, 2, formatDateTime(record.getUpdatedAt()));
+
+        writeAuditCell(keyRow, 3, "exportedBy");
+        writeAuditCell(valueRow, 3, normalizeAuditValue(record.getExportedBy()));
+
+        writeAuditCell(keyRow, 4, "exportedAt");
+        writeAuditCell(valueRow, 4, formatDateTime(record.getExportedAt()));
+    }
+
+    private void writeAuditCell(Row row, int columnIndex, String value) {
+        Cell cell = row.getCell(columnIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+        cell.setCellValue(Optional.ofNullable(value).orElse(""));
+    }
+
+    private String normalizeAuditValue(String value) {
+        return StringUtils.hasText(value) ? value.trim() : "";
     }
 
     private String buildRemark(InspectionRecord record) {
@@ -171,85 +223,97 @@ public class InspectionRecordExcelExporter {
 
     private String buildNameWithTime(String name, LocalDateTime time) {
         StringBuilder builder = new StringBuilder();
-        if (StringUtils.hasText(name)) {
-            builder.append(name.trim());
+        String normalizedName = normalizeAuditValue(name);
+        if (StringUtils.hasText(normalizedName)) {
+            builder.append(normalizedName);
         }
-        if (time != null) {
+        String formattedTime = formatDateTime(time);
+        if (StringUtils.hasText(formattedTime)) {
             if (builder.length() > 0) {
                 builder.append(" ");
             }
-            builder.append("(").append(DATE_TIME_FORMATTER.format(time)).append(")");
+            builder.append("(").append(formattedTime).append(")");
         }
         return builder.length() == 0 ? "无" : builder.toString();
     }
 
-    private void writePhotos(Workbook workbook, XSSFSheet sheet, List<PhotoItem> photos) throws IOException {
-        if (photos.isEmpty()) {
+    private void writePhotos(XSSFWorkbook workbook, List<PhotoItem> photos) {
+        XSSFSheet templateSheet = locatePhotoTemplate(workbook);
+        if (templateSheet == null) {
             return;
         }
-        // 根据照片数量动态准备插槽（复制模板页、计算坐标等）。
-        List<PhotoSlotTemplate> slots = preparePhotoSlots(sheet, photos.size());
+        int templateIndex = workbook.getSheetIndex(templateSheet);
+        if (photos.isEmpty()) {
+            workbook.removeSheetAt(templateIndex);
+            return;
+        }
+
         CreationHelper helper = workbook.getCreationHelper();
-        XSSFDrawing drawing = sheet.createDrawingPatriarch();
+        int totalPages = (int) Math.ceil(photos.size() / (double) PHOTOS_PER_PAGE);
+        for (int page = 0; page < totalPages; page++) {
+            XSSFSheet photoSheet = workbook.cloneSheet(templateIndex);
+            int newIndex = workbook.getSheetIndex(photoSheet);
+            workbook.setSheetName(newIndex, "照片页" + (page + 1));
+            XSSFDrawing drawing = photoSheet.createDrawingPatriarch();
 
-        for (int i = 0; i < photos.size(); i++) {
-            PhotoItem photo = photos.get(i);
-            if (photo == null || !StringUtils.hasText(photo.getImagePath())) {
-                continue;
+            for (int slotIndex = 0; slotIndex < PAGE_PHOTO_SLOTS.size(); slotIndex++) {
+                int photoIndex = page * PAGE_PHOTO_SLOTS.size() + slotIndex;
+                PhotoSlotTemplate slot = PAGE_PHOTO_SLOTS.get(slotIndex);
+                if (photoIndex >= photos.size()) {
+                    clearDescriptionCell(photoSheet, slot);
+                    continue;
+                }
+
+                PhotoItem photo = photos.get(photoIndex);
+                if (photo == null || !StringUtils.hasText(photo.getImagePath())) {
+                    clearDescriptionCell(photoSheet, slot);
+                    continue;
+                }
+
+                try {
+                    ImageResource resource = loadImageResource(photo.getImagePath());
+                    if (resource == null) {
+                        clearDescriptionCell(photoSheet, slot);
+                        continue;
+                    }
+                    int pictureIndex = workbook.addPicture(resource.data(), resource.pictureType());
+                    XSSFClientAnchor anchor = (XSSFClientAnchor) helper.createClientAnchor();
+                    configureAnchor(photoSheet, anchor, slot, resource);
+                    anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
+                    drawing.createPicture(anchor, pictureIndex);
+                    writePhotoDescription(photoSheet, slot, defaultText(photo.getDescription()));
+                } catch (IOException ex) {
+                    log.warn("巡查照片写入失败: {}", photo.getImagePath(), ex);
+                    clearDescriptionCell(photoSheet, slot);
+                }
             }
-            PhotoSlotTemplate slot = slots.get(i);
-            insertPhoto(workbook, helper, drawing, sheet, slot, photo);
+        }
+
+        int templatePosition = workbook.getSheetIndex(templateSheet);
+        if (templatePosition >= 0) {
+            workbook.removeSheetAt(templatePosition);
         }
     }
 
-    private List<PhotoSlotTemplate> preparePhotoSlots(XSSFSheet sheet, int photoCount) {
-        List<PhotoSlotTemplate> slots = new ArrayList<>(BASE_PHOTO_SLOTS);
-        if (photoCount <= BASE_PHOTO_SLOTS.size()) {
-            return slots;
+    private XSSFSheet locatePhotoTemplate(XSSFWorkbook workbook) {
+        XSSFSheet sheet = workbook.getSheet("Sheet2");
+        if (sheet != null) {
+            return sheet;
         }
-        int additionalPhotos = photoCount - BASE_PHOTO_SLOTS.size();
-        int additionalPages = (int) Math.ceil(additionalPhotos / (double) PHOTOS_PER_PAGE);
-
-        int baseStart = THIRD_PAGE_START_ROW - 1;
-        int baseEnd = THIRD_PAGE_END_ROW - 1;
-        int insertPosition = baseEnd + 1;
-        for (int i = 0; i < additionalPages; i++) {
-            // 模板第三页作为扩展页模板，逐页复制后计算新的照片、说明单元格位置。
-            sheet.copyRows(baseStart, baseEnd, insertPosition, new CellCopyPolicy());
-            int rowShift = ROWS_PER_ADDITIONAL_PAGE * (i + 1);
-            for (PhotoSlotTemplate template : ADDITIONAL_PAGE_SLOTS) {
-                slots.add(template.shift(rowShift));
-            }
-            insertPosition += ROWS_PER_ADDITIONAL_PAGE;
+        if (workbook.getNumberOfSheets() > 1) {
+            return workbook.getSheetAt(1);
         }
-        return slots;
+        log.warn("巡查照片模板页缺失，跳过照片写入");
+        return null;
     }
 
-    private void insertPhoto(Workbook workbook, CreationHelper helper, XSSFDrawing drawing, XSSFSheet sheet,
-                              PhotoSlotTemplate slot, PhotoItem photo) throws IOException {
-        Path imagePath = Paths.get(photo.getImagePath());
-        if (!Files.exists(imagePath)) {
-            throw new IOException("巡查照片不存在：" + imagePath);
+    private void clearDescriptionCell(XSSFSheet sheet, PhotoSlotTemplate slot) {
+        Row row = sheet.getRow(slot.descRowStart() - 1);
+        if (row == null) {
+            row = sheet.createRow(slot.descRowStart() - 1);
         }
-        byte[] imageBytes = Files.readAllBytes(imagePath);
-        int pictureType = resolvePictureType(imagePath.getFileName().toString());
-        int pictureIndex = workbook.addPicture(imageBytes, pictureType);
-
-        ClientAnchor anchor = helper.createClientAnchor();
-        anchor.setCol1(slot.col1() - 1);
-        anchor.setRow1(slot.row1() - 1);
-        anchor.setCol2(slot.col2());
-        anchor.setRow2(slot.row2());
-        anchor.setDx1(Units.toEMU(10));
-        anchor.setDy1(Units.toEMU(10));
-        anchor.setDx2(Units.toEMU(10));
-        anchor.setDy2(Units.toEMU(10));
-        anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
-
-        XSSFPicture picture = drawing.createPicture(anchor, pictureIndex);
-
-        // 图片说明单独写入模板预留的文字区域。
-        writePhotoDescription(sheet, slot, defaultText(photo.getDescription()));
+        Cell cell = row.getCell(slot.descColumn() - 1, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+        cell.setCellValue("");
     }
 
     private void writePhotoDescription(Sheet sheet, PhotoSlotTemplate slot, String description) {
@@ -272,6 +336,195 @@ public class InspectionRecordExcelExporter {
                 extraCell.setCellValue("");
             }
         }
+    }
+
+    private void configureAnchor(XSSFSheet sheet, XSSFClientAnchor anchor, PhotoSlotTemplate slot, ImageResource resource) {
+        anchor.setCol1(slot.col1() - 1);
+        anchor.setRow1(slot.row1() - 1);
+
+        long slotWidthEmu = calculateSlotWidthEmu(sheet, slot);
+        long slotHeightEmu = calculateSlotHeightEmu(sheet, slot);
+        long marginEmu = Units.toEMU(PHOTO_MARGIN_POINTS);
+
+        long availableWidth = Math.max(slotWidthEmu - 2 * marginEmu, slotWidthEmu / 2);
+        long availableHeight = Math.max(slotHeightEmu - 2 * marginEmu, slotHeightEmu / 2);
+
+        long imageWidth = resource.widthPx() > 0 ? Math.round(resource.widthPx() * EMU_PER_PIXEL) : availableWidth;
+        long imageHeight = resource.heightPx() > 0 ? Math.round(resource.heightPx() * EMU_PER_PIXEL) : availableHeight;
+
+        double widthScale = availableWidth > 0 ? (double) availableWidth / imageWidth : 1.0;
+        double heightScale = availableHeight > 0 ? (double) availableHeight / imageHeight : 1.0;
+        double scale = Math.min(widthScale, heightScale);
+        scale = Math.min(scale, 1.0);
+
+        long scaledWidth = Math.max(1L, Math.round(imageWidth * scale));
+        long scaledHeight = Math.max(1L, Math.round(imageHeight * scale));
+
+        long widthFromLeft = Math.min(slotWidthEmu - 1, marginEmu + scaledWidth);
+        long heightFromTop = Math.min(slotHeightEmu - 1, marginEmu + scaledHeight);
+
+        AnchorCoordinate columnExtent = calculateColumnExtent(sheet, slot.col1() - 1, slot.col2() - 1, widthFromLeft);
+        AnchorCoordinate rowExtent = calculateRowExtent(sheet, slot.row1() - 1, slot.row2() - 1, heightFromTop);
+
+        anchor.setDx1((int) Math.min(marginEmu, Integer.MAX_VALUE));
+        anchor.setDy1((int) Math.min(marginEmu, Integer.MAX_VALUE));
+        anchor.setCol2(columnExtent.index());
+        anchor.setDx2(columnExtent.offset());
+        anchor.setRow2(rowExtent.index());
+        anchor.setDy2(rowExtent.offset());
+    }
+
+    private long calculateSlotWidthEmu(XSSFSheet sheet, PhotoSlotTemplate slot) {
+        long width = 0;
+        for (int column = slot.col1() - 1; column <= slot.col2() - 1; column++) {
+            width += columnWidthInEmu(sheet, column);
+        }
+        return width;
+    }
+
+    private long calculateSlotHeightEmu(XSSFSheet sheet, PhotoSlotTemplate slot) {
+        long height = 0;
+        for (int rowIndex = slot.row1() - 1; rowIndex <= slot.row2() - 1; rowIndex++) {
+            height += rowHeightInEmu(sheet, rowIndex);
+        }
+        return height;
+    }
+
+    private AnchorCoordinate calculateColumnExtent(Sheet sheet, int startColumn, int endColumn, long widthEmu) {
+        long consumed = 0;
+        for (int column = startColumn; column <= endColumn; column++) {
+            long columnWidth = columnWidthInEmu(sheet, column);
+            long next = consumed + columnWidth;
+            if (next >= widthEmu) {
+                long offset = Math.max(0, widthEmu - consumed);
+                if (offset == 0 && column > startColumn) {
+                    long previousWidth = columnWidthInEmu(sheet, column - 1);
+                    return new AnchorCoordinate(column - 1, (int) Math.min(previousWidth, Integer.MAX_VALUE));
+                }
+                return new AnchorCoordinate(column, (int) Math.min(offset, Integer.MAX_VALUE));
+            }
+            consumed = next;
+        }
+        return new AnchorCoordinate(endColumn, 0);
+    }
+
+    private AnchorCoordinate calculateRowExtent(Sheet sheet, int startRow, int endRow, long heightEmu) {
+        long consumed = 0;
+        for (int rowIndex = startRow; rowIndex <= endRow; rowIndex++) {
+            long rowHeight = rowHeightInEmu(sheet, rowIndex);
+            long next = consumed + rowHeight;
+            if (next >= heightEmu) {
+                long offset = Math.max(0, heightEmu - consumed);
+                if (offset == 0 && rowIndex > startRow) {
+                    long previousHeight = rowHeightInEmu(sheet, rowIndex - 1);
+                    return new AnchorCoordinate(rowIndex - 1, (int) Math.min(previousHeight, Integer.MAX_VALUE));
+                }
+                return new AnchorCoordinate(rowIndex, (int) Math.min(offset, Integer.MAX_VALUE));
+            }
+            consumed = next;
+        }
+        return new AnchorCoordinate(endRow, 0);
+    }
+
+    private long columnWidthInEmu(Sheet sheet, int columnIndex) {
+        double pixels = SheetUtil.getColumnWidthInPixels(sheet, columnIndex);
+        if (Double.isNaN(pixels) || pixels <= 0) {
+            pixels = 64.0;
+        }
+        return Math.max(EMU_PER_PIXEL, Math.round(pixels * EMU_PER_PIXEL));
+    }
+
+    private long rowHeightInEmu(Sheet sheet, int rowIndex) {
+        Row row = sheet.getRow(rowIndex);
+        double points = row != null ? row.getHeightInPoints() : sheet.getDefaultRowHeightInPoints();
+        if (points <= 0) {
+            points = sheet.getDefaultRowHeightInPoints();
+        }
+        return Math.max(EMU_PER_POINT, Math.round(points * EMU_PER_POINT));
+    }
+
+    private ImageResource loadImageResource(String location) throws IOException {
+        String value = location.trim();
+        if (value.startsWith("data:image")) {
+            return loadFromDataUri(value);
+        }
+        try {
+            Path path = Paths.get(value);
+            if (Files.exists(path)) {
+                byte[] data = Files.readAllBytes(path);
+                int type = resolvePictureType(path.getFileName().toString());
+                return buildImageResource(data, type);
+            }
+        } catch (InvalidPathException ignored) {
+            // treat as base64 below
+        }
+        ImageResource base64Resource = tryDecodeBase64(value);
+        if (base64Resource != null) {
+            return base64Resource;
+        }
+        log.warn("无法识别的巡查照片路径：{}", location);
+        return null;
+    }
+
+    private ImageResource loadFromDataUri(String uri) throws IOException {
+        int commaIndex = uri.indexOf(',');
+        if (commaIndex < 0) {
+            throw new IOException("无效的图片数据: " + uri.substring(0, Math.min(uri.length(), 32)));
+        }
+        String metadata = uri.substring(5, commaIndex);
+        int semicolonIndex = metadata.indexOf(';');
+        String mime = semicolonIndex >= 0 ? metadata.substring(0, semicolonIndex) : metadata;
+        String base64 = uri.substring(commaIndex + 1);
+        byte[] data = Base64.getDecoder().decode(base64);
+        int type = resolvePictureTypeFromMime(mime);
+        return buildImageResource(data, type);
+    }
+
+    private ImageResource tryDecodeBase64(String value) {
+        try {
+            byte[] data = Base64.getDecoder().decode(value);
+            int type = detectPictureType(data);
+            return buildImageResource(data, type);
+        } catch (IllegalArgumentException | IOException ex) {
+            return null;
+        }
+    }
+
+    private ImageResource buildImageResource(byte[] data, int pictureType) throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(data)) {
+            BufferedImage image = ImageIO.read(inputStream);
+            if (image == null) {
+                throw new IOException("无法解析图片内容");
+            }
+            return new ImageResource(data, pictureType, image.getWidth(), image.getHeight());
+        }
+    }
+
+    private int resolvePictureTypeFromMime(String mimeType) {
+        String normalized = mimeType.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "image/png" -> Workbook.PICTURE_TYPE_PNG;
+            case "image/jpeg", "image/jpg" -> Workbook.PICTURE_TYPE_JPEG;
+            case "image/bmp" -> Workbook.PICTURE_TYPE_DIB;
+            default -> throw new IllegalArgumentException("不支持的图片类型: " + mimeType);
+        };
+    }
+
+    private int detectPictureType(byte[] data) {
+        if (data.length >= 8
+                && data[0] == (byte) 0x89
+                && data[1] == (byte) 0x50
+                && data[2] == (byte) 0x4E
+                && data[3] == (byte) 0x47) {
+            return Workbook.PICTURE_TYPE_PNG;
+        }
+        if (data.length >= 2 && (data[0] & 0xFF) == 0xFF && (data[1] & 0xFF) == 0xD8) {
+            return Workbook.PICTURE_TYPE_JPEG;
+        }
+        if (data.length >= 2 && data[0] == 0x42 && data[1] == 0x4D) {
+            return Workbook.PICTURE_TYPE_DIB;
+        }
+        throw new IllegalArgumentException("无法识别的图片格式");
     }
 
     private void setCellToRightOfLabel(Sheet sheet, String label, String value) {
@@ -368,14 +621,14 @@ public class InspectionRecordExcelExporter {
         appendCategory(sb, "五、涉路施工检查", effective.getConstructionChecks());
         appendCategory(sb, "六、违法侵权事件", effective.getIllegalInfringements());
         appendCategory(sb, "七、其他情况", effective.getOtherMatters());
-        return sb.toString().trim();
+        return sb.toString().stripTrailing();
     }
 
     private void appendCategory(StringBuilder sb, String header, List<String> items) {
         if (sb.length() > 0) {
             sb.append(System.lineSeparator());
         }
-        sb.append(header).append(System.lineSeparator());
+        sb.append(header).append("：").append(System.lineSeparator());
         writeItems(sb, items);
     }
 
@@ -383,10 +636,14 @@ public class InspectionRecordExcelExporter {
         if (sb.length() > 0) {
             sb.append(System.lineSeparator());
         }
-        sb.append(header).append(System.lineSeparator());
-        for (SubCategory sub : subCategories) {
+        sb.append(header).append("：").append(System.lineSeparator());
+        for (int i = 0; i < subCategories.length; i++) {
+            SubCategory sub = subCategories[i];
             sb.append(sub.title()).append(System.lineSeparator());
             writeItems(sb, sub.items());
+            if (i < subCategories.length - 1) {
+                sb.append(System.lineSeparator());
+            }
         }
     }
 
@@ -409,6 +666,10 @@ public class InspectionRecordExcelExporter {
 
     private String formatDate(LocalDate date) {
         return date == null ? "" : DATE_FORMATTER.format(date);
+    }
+
+    private String formatDateTime(LocalDateTime time) {
+        return time == null ? "" : DATE_TIME_FORMATTER.format(time);
     }
 
     private String ensureExcelExtension(String fileName) {
@@ -440,10 +701,12 @@ public class InspectionRecordExcelExporter {
 
     private record PhotoSlotTemplate(int col1, int row1, int col2, int row2,
                                      int descRowStart, int descRowEnd, int descColumn) {
-        PhotoSlotTemplate shift(int rowShift) {
-            return new PhotoSlotTemplate(col1, row1 + rowShift, col2, row2 + rowShift,
-                    descRowStart + rowShift, descRowEnd + rowShift, descColumn);
-        }
+    }
+
+    private record AnchorCoordinate(int index, int offset) {
+    }
+
+    private record ImageResource(byte[] data, int pictureType, int widthPx, int heightPx) {
     }
 
     private record SubCategory(String title, List<String> items) {

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/InspectionRecord.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/domain/model/InspectionRecord.java
@@ -27,6 +27,11 @@ public class InspectionRecord {
     private LocalDate date;
 
     /**
+     * 单位名称，用于表头展示。
+     */
+    private String unitName;
+
+    /**
      * 天气情况。
      */
     private String weather;

--- a/xrcgs-module-road-safety/src/test/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporterTest.java
+++ b/xrcgs-module-road-safety/src/test/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporterTest.java
@@ -10,23 +10,25 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.nio.file.Paths;
-import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFDrawing;
+import org.apache.poi.xssf.usermodel.XSSFPicture;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.FileSystemResource;
@@ -45,7 +47,7 @@ class InspectionRecordExcelExporterTest {
 
     @Test
     void shouldExportInspectionRecordWithPhotosAndHandlingDetails() throws Exception {
-        Path template = createTemplateWorkbook(tempDir.resolve("excel/inspectionRecord.xlsx"));
+        Path template = Paths.get("src/test/resources/excel/inspection_record.xlsx");
         InspectionRecordExcelExporter exporter = new InspectionRecordExcelExporter(new FileSystemResource(template));
         Path photoDir = Files.createDirectories(tempDir.resolve("photos"));
         List<PhotoItem> photos = new ArrayList<>();
@@ -56,15 +58,20 @@ class InspectionRecordExcelExporterTest {
 
         HandlingCategoryGroup categoryGroup = HandlingCategoryGroup.builder()
                 .roadDamage(List.of("路面沉陷处设置警示标志。"))
+                .trafficAccidents(List.of("收费站出口追尾事故处理完毕。"))
                 .roadRescue(List.of("拖移故障车辆1辆。"))
+                .facilityCompensations(Collections.emptyList())
                 .largeVehicleChecks(List.of("检查大件运输车辆2辆，手续齐全。"))
                 .overloadVehicleHandling(List.of("劝返超限车辆1辆。"))
+                .constructionChecks(Collections.emptyList())
+                .illegalInfringements(Collections.emptyList())
                 .otherMatters(List.of("与交警联合巡查。"))
                 .build();
 
         InspectionRecord record = InspectionRecord.builder()
                 .id(1L)
                 .date(LocalDate.of(2024, 12, 1))
+                .unitName("乌鲁木齐葛洲坝电建路桥绕城高速公路有限公司")
                 .weather("晴")
                 .patrolTeam("巡查一队")
                 .location("K10+000-K20+000")
@@ -81,52 +88,91 @@ class InspectionRecordExcelExporterTest {
                 .exportFileName("record.xlsx")
                 .build();
 
-        Path exportDir = Files.createDirectories(Paths.get("src/test/resources/export"));
-        Path output = exportDir.resolve("record.xlsx");
-        Files.deleteIfExists(output);
-
-        output = exporter.export(record, exportDir);
+        Path exportDir = Files.createDirectories(tempDir.resolve("export"));
+        Path output = exporter.export(record, exportDir);
         log.info("巡查记录导出文件路径: {}", output.toAbsolutePath());
         assertThat(Files.exists(output)).isTrue();
 
         try (InputStream inputStream = Files.newInputStream(output);
              Workbook workbook = WorkbookFactory.create(inputStream)) {
-            Sheet sheet = workbook.getSheetAt(0);
+            XSSFSheet infoSheet = (XSSFSheet) workbook.getSheetAt(0);
 
-            String dateText = readValueRightOfLabel(sheet, "巡查时间");
-            assertThat(dateText).contains("2024年12月01日");
+            assertThat(infoSheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("巡查记录表");
+            assertThat(infoSheet.getRow(1).getCell(0).getStringCellValue())
+                    .isEqualTo("单位：" + record.getUnitName());
 
-            Row dateRow = sheet.getRow(2);
-            assertThat(dateRow.getCell(1).getStringCellValue()).isEqualTo("：");
-            Cell targetCell = findTargetCell(sheet, "巡查时间");
-            assertThat(targetCell).isNotNull();
-            assertThat(targetCell.getColumnIndex()).isEqualTo(2);
-            assertThat(targetCell.getStringCellValue()).contains("2024年12月01日");
-            assertThat(targetCell.getCellStyle().getBorderBottom()).isEqualTo(BorderStyle.THIN);
+            assertThat(readValueRightOfLabel(infoSheet, "巡查时间")).contains("2024年12月01日");
+            assertThat(readValueRightOfLabel(infoSheet, "天气情况")).isEqualTo("晴");
+            assertThat(readValueRightOfLabel(infoSheet, "巡查人员")).isEqualTo("巡查一队");
 
-            String handlingText = readValueRightOfLabel(sheet, "巡查、处理情况");
-            assertThat(handlingText)
-                    .contains("一、道路病害或损坏情况")
-                    .contains("路面沉陷处设置警示标志")
-                    .contains("二、交通事故或清障救援情况")
+            String handlingText = readValueRightOfLabel(infoSheet, "巡查、处理情况");
+            String normalizedHandling = handlingText.replace("\r\n", "\n");
+            assertThat(normalizedHandling)
+                    .contains("一、道路病害或损坏情况：")
+                    .contains("- 路面沉陷处设置警示标志。")
+                    .contains("二、交通事故或清障救援情况：")
+                    .contains("（交通事故）")
+                    .contains("- 收费站出口追尾事故处理完毕。")
                     .contains("（清障救援）")
-                    .contains("拖移故障车辆1辆")
-                    .contains("七、其他情况");
+                    .contains("- 拖移故障车辆1辆。")
+                    .contains("三、设施赔补偿情况：\n无")
+                    .contains("七、其他情况：")
+                    .contains("- 与交警联合巡查。");
 
-            String remarkText = readValueRightOfLabel(sheet, "备注");
-            assertThat(remarkText).contains("创建：张三 (2024年12月01日 09:30)");
-            assertThat(remarkText).contains("导出：李四 (2024年12月01日 18:30)");
+            String remarkText = readValueRightOfLabel(infoSheet, "备注").replace("\r\n", "\n");
+            assertThat(remarkText)
+                    .contains("创建：张三 (2024年12月01日 09:30)")
+                    .contains("最后更新时间：2024年12月01日 18:00")
+                    .contains("导出：李四 (2024年12月01日 18:30)");
 
-            boolean foundFifthDescription = false;
-            for (Row row : sheet) {
-                Cell cell = row.getCell(1);
-                if (cell != null && "第5张照片".equals(cell.getStringCellValue())) {
-                    assertThat(row.getRowNum()).isGreaterThanOrEqualTo(114);
-                    foundFifthDescription = true;
-                    break;
+            boolean auditFound = false;
+            for (Row row : infoSheet) {
+                if (row instanceof XSSFRow xssfRow && xssfRow.getZeroHeight()) {
+                    Cell keyCell = row.getCell(0);
+                    if (keyCell != null && "createdBy".equals(keyCell.getStringCellValue())) {
+                        XSSFRow valueRow = (XSSFRow) infoSheet.getRow(row.getRowNum() + 1);
+                        assertThat(valueRow).isNotNull();
+                        assertThat(valueRow.getCell(0).getStringCellValue()).isEqualTo("张三");
+                        assertThat(valueRow.getCell(1).getStringCellValue()).contains("2024年12月01日 09:30");
+                        assertThat(valueRow.getCell(4).getStringCellValue()).contains("2024年12月01日 18:30");
+                        auditFound = true;
+                        break;
+                    }
                 }
             }
-            assertThat(foundFifthDescription).isTrue();
+            assertThat(auditFound).isTrue();
+
+            int expectedPhotoSheets = (int) Math.ceil(photos.size() / 2.0);
+            assertThat(workbook.getSheet("Sheet2")).isNull();
+            assertThat(workbook.getNumberOfSheets()).isEqualTo(1 + expectedPhotoSheets);
+
+            for (int page = 1; page <= expectedPhotoSheets; page++) {
+                XSSFSheet photoSheet = workbook.getSheet("照片页" + page);
+                assertThat(photoSheet).isNotNull();
+
+                XSSFDrawing drawing = (XSSFDrawing) photoSheet.getDrawingPatriarch();
+                assertThat(drawing).isNotNull();
+                long pictureCount = drawing.getShapes().stream().filter(XSSFPicture.class::isInstance).count();
+                int startIndex = (page - 1) * 2;
+                int expectedPictures = Math.min(2, Math.max(0, photos.size() - startIndex));
+                assertThat(pictureCount).isEqualTo(expectedPictures);
+
+                Row topDescRow = photoSheet.getRow(26);
+                if (startIndex < photos.size()) {
+                    assertThat(topDescRow).isNotNull();
+                    assertThat(topDescRow.getCell(0).getStringCellValue())
+                            .isEqualTo("第" + (startIndex + 1) + "张照片");
+                }
+                Row bottomDescRow = photoSheet.getRow(51);
+                if (startIndex + 1 < photos.size()) {
+                    assertThat(bottomDescRow).isNotNull();
+                    assertThat(bottomDescRow.getCell(0).getStringCellValue())
+                            .isEqualTo("第" + (startIndex + 2) + "张照片");
+                } else {
+                    Cell bottomCell = bottomDescRow == null ? null : bottomDescRow.getCell(0);
+                    assertThat(bottomCell == null ? "" : bottomCell.getStringCellValue()).isEmpty();
+                }
+            }
         }
     }
 
@@ -140,64 +186,6 @@ class InspectionRecordExcelExporterTest {
         graphics.dispose();
         javax.imageio.ImageIO.write(image, "jpg", path.toFile());
         return path;
-    }
-
-    /**
-     * 构造一个满足导出逻辑的最小化模板，避免在仓库中提交真实业务模板。
-     */
-    private Path createTemplateWorkbook(Path path) throws IOException {
-        Files.createDirectories(path.getParent());
-        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
-            Sheet sheet = workbook.createSheet("模板");
-            for (int i = 0; i <= 150; i++) {
-                sheet.createRow(i);
-            }
-
-            createLabeledRow(sheet, 2, "巡查时间");
-            createLabeledRow(sheet, 3, "天气情况");
-            createLabeledRow(sheet, 4, "巡查人员");
-            createLabeledRow(sheet, 5, "巡查里程");
-            createLabeledRow(sheet, 6, "巡查路段");
-
-            sheet.getRow(7).createCell(0).setCellValue("巡查、处理情况");
-            addColonCell(sheet, 7, 1);
-            createMergedInputCell(sheet, 7, 2, 9, BorderStyle.THIN);
-
-            sheet.getRow(11).createCell(0).setCellValue("备注");
-            addColonCell(sheet, 11, 1);
-            createMergedInputCell(sheet, 11, 2, 5, BorderStyle.THIN);
-
-            try (OutputStream outputStream = Files.newOutputStream(path)) {
-                workbook.write(outputStream);
-            }
-        }
-        return path;
-    }
-
-    private void createLabeledRow(Sheet sheet, int rowIndex, String label) {
-        sheet.getRow(rowIndex).createCell(0).setCellValue(label);
-        addColonCell(sheet, rowIndex, 1);
-        createMergedInputCell(sheet, rowIndex, 2, 4, BorderStyle.THIN);
-    }
-
-    private void addColonCell(Sheet sheet, int rowIndex, int columnIndex) {
-        sheet.getRow(rowIndex).createCell(columnIndex).setCellValue("：");
-    }
-
-    private void createMergedInputCell(Sheet sheet, int rowIndex, int startColumn, int columnSpan, BorderStyle border) {
-        Row row = sheet.getRow(rowIndex);
-        for (int i = 0; i < columnSpan; i++) {
-            row.createCell(startColumn + i);
-        }
-        sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex, startColumn, startColumn + columnSpan - 1));
-        var workbook = sheet.getWorkbook();
-        var style = workbook.createCellStyle();
-        style.setBorderBottom(border);
-        style.setBorderTop(border);
-        style.setBorderLeft(border);
-        style.setBorderRight(border);
-        style.setWrapText(true);
-        row.getCell(startColumn).setCellStyle(style);
     }
 
     private String readValueRightOfLabel(Sheet sheet, String label) {


### PR DESCRIPTION
## Summary
- align the inspection record exporter with the new Excel template, including header styling updates, classified handling text formatting, hidden audit metadata, and cloned photo pages with anchored images
- add a unitName field to the inspection record domain model to populate the Sheet1 header
- refresh the Excel exporter test to rely on the official template and verify photo pagination, descriptions, and hidden metadata

## Testing
- mvn -pl xrcgs-module-road-safety -Dtest=InspectionRecordExcelExporterTest test *(fails: missing internal module artifacts in the local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e28a956d7c83219154bcd13dfc638d