### PR TITLE
feat: support road safety module multi datasource

### DIFF
--- a/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
+++ b/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
@@ -10,8 +10,10 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ConfigurationPropertiesScan(basePackages = "com.xrcgs") // 关键：让 @ConfigurationProperties 生效
 @MapperScan(
         basePackages = {
-                "com.xrcgs.*.mapper",   // 你原有 IAM 模块的 mapper
-                "com.xrcgs.auth.user"     // 新增 auth 模块里的 SysUserMapper 包
+                "com.xrcgs.iam.mapper",
+                "com.xrcgs.syslog.mapper",
+                "com.xrcgs.file.mapper",
+                "com.xrcgs.auth.user"
         },
         nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
 )

--- a/xrcgs-boot/src/main/resources/application-dev.yml
+++ b/xrcgs-boot/src/main/resources/application-dev.yml
@@ -8,6 +8,15 @@ spring:
       minimum-idle: 1
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+    road-safety:
+      url: jdbc:mysql://localhost:3306/xrcgs_roadSafety?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+      username: ${DB_ROAD_SAFETY_USER:${DB_USER:root}}
+      password: ${DB_ROAD_SAFETY_PASS:${DB_PASS:root}}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        maximum-pool-size: 5
+        minimum-idle: 1
+
   data:
     redis:
       host: localhost

--- a/xrcgs-boot/src/main/resources/application-prod.yml
+++ b/xrcgs-boot/src/main/resources/application-prod.yml
@@ -8,6 +8,15 @@ spring:
       minimum-idle: 1
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+    road-safety:
+      url: jdbc:mysql://localhost:3306/xrcgs_roadSafety?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+      username: ${DB_ROAD_SAFETY_USER:${DB_USER}}
+      password: ${DB_ROAD_SAFETY_PASS:${DB_PASS}}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        maximum-pool-size: 5
+        minimum-idle: 1
+
   data:
     redis:
       host: localhost

--- a/xrcgs-infrastructure/src/main/java/com/xrcgs/infrastructure/config/RoadSafetyDataSourceConfig.java
+++ b/xrcgs-infrastructure/src/main/java/com/xrcgs/infrastructure/config/RoadSafetyDataSourceConfig.java
@@ -1,0 +1,105 @@
+package com.xrcgs.infrastructure.config;
+
+import com.baomidou.mybatisplus.autoconfigure.MybatisPlusProperties;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+
+/**
+ * 数据源配置：为路产安全模块提供独立的数据源、会话工厂与事务管理。
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "spring.datasource.road-safety", name = "url")
+public class RoadSafetyDataSourceConfig {
+
+    private final MybatisPlusInterceptor mybatisPlusInterceptor;
+    private final MybatisPlusProperties mybatisPlusProperties;
+
+    public RoadSafetyDataSourceConfig(MybatisPlusInterceptor mybatisPlusInterceptor,
+                                      MybatisPlusProperties mybatisPlusProperties) {
+        this.mybatisPlusInterceptor = mybatisPlusInterceptor;
+        this.mybatisPlusProperties = mybatisPlusProperties;
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.road-safety")
+    public DataSourceProperties roadSafetyDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "roadSafetyDataSource")
+    @ConfigurationProperties("spring.datasource.road-safety.hikari")
+    public DataSource roadSafetyDataSource(@Qualifier("roadSafetyDataSourceProperties") DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    }
+
+    @Bean(name = "roadSafetySqlSessionFactory")
+    public SqlSessionFactory roadSafetySqlSessionFactory(@Qualifier("roadSafetyDataSource") DataSource dataSource) throws Exception {
+        var factory = new MybatisSqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        factory.setPlugins(mybatisPlusInterceptor);
+
+        var configuration = new MybatisConfiguration();
+        configuration.setMapUnderscoreToCamelCase(true);
+        factory.setConfiguration(configuration);
+
+        if (mybatisPlusProperties.getGlobalConfig() != null) {
+            factory.setGlobalConfig(mybatisPlusProperties.getGlobalConfig());
+        }
+
+        if (StringUtils.hasText(mybatisPlusProperties.getTypeAliasesPackage())) {
+            factory.setTypeAliasesPackage(mybatisPlusProperties.getTypeAliasesPackage());
+        }
+        if (StringUtils.hasText(mybatisPlusProperties.getTypeHandlersPackage())) {
+            factory.setTypeHandlersPackage(mybatisPlusProperties.getTypeHandlersPackage());
+        }
+
+        var mapperLocations = resolveMapperLocations("classpath*:mapper/roadsafety/**/*.xml");
+        if (mapperLocations.length > 0) {
+            factory.setMapperLocations(mapperLocations);
+        }
+
+        return factory.getObject();
+    }
+
+    @Bean(name = "roadSafetySqlSessionTemplate")
+    public SqlSessionTemplate roadSafetySqlSessionTemplate(@Qualifier("roadSafetySqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+
+    @Bean(name = "roadSafetyTransactionManager")
+    public DataSourceTransactionManager roadSafetyTransactionManager(@Qualifier("roadSafetyDataSource") DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    private Resource[] resolveMapperLocations(String... mapperLocations) throws IOException {
+        List<Resource> resources = new ArrayList<>();
+        var resolver = new PathMatchingResourcePatternResolver();
+        for (String mapperLocation : mapperLocations) {
+            if (!StringUtils.hasText(mapperLocation)) {
+                continue;
+            }
+            resources.addAll(List.of(resolver.getResources(mapperLocation)));
+        }
+        return resources.toArray(new Resource[0]);
+    }
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyModuleConfiguration.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyModuleConfiguration.java
@@ -1,12 +1,19 @@
 package com.xrcgs.roadsafety.config;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 /**
  * 基础配置入口，提供路产安全模块的组件扫描能力。
  */
 @Configuration
 @ComponentScan(basePackages = "com.xrcgs.roadsafety")
+@MapperScan(
+        basePackages = "com.xrcgs.roadsafety.**.mapper",
+        sqlSessionTemplateRef = "roadSafetySqlSessionTemplate",
+        nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
+)
 public class RoadSafetyModuleConfiguration {
 }


### PR DESCRIPTION
## Summary
- configure a dedicated road-safety MyBatis infrastructure (DataSource, SqlSessionFactory, transaction manager)
- scope mapper scanning so the road-safety module uses its own SqlSessionTemplate
- expose road-safety datasource properties for both dev and prod profiles

## Testing
- mvn -pl xrcgs-boot -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e34dce77608321b5529a0018af2e6d