### PR TITLE
feat: allow road safety module to fall back to primary db

### DIFF
--- a/docs/database-config.md
+++ b/docs/database-config.md
@@ -1,0 +1,42 @@
+# 数据库外部配置说明
+
+## 多数据源在系统中的切换方式
+
+当前工程通过“为不同业务模块分别注入 `SqlSessionTemplate`”的方式来切换数据库：
+
+1. `RoadSafetyDataSourceConfig` 会在配置文件存在 `spring.datasource.road-safety.url` 时生效（`@ConditionalOnProperty`）。它手动声明了路产安全库的 `DataSource`、`SqlSessionFactory`、`SqlSessionTemplate` 与 `DataSourceTransactionManager`。这样一来，该模板绑定在独立的连接池 `roadSafetyDataSource` 上。 【F:xrcgs-infrastructure/src/main/java/com/xrcgs/infrastructure/config/RoadSafetyDataSourceConfig.java†L31-L89】
+2. 路产安全模块在检测到独立模板存在时，会通过 `RoadSafetyMapperConfiguration` 把 Mapper 绑定到 `roadSafetySqlSessionTemplate` 上，从而连到路产安全库。 【F:xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperConfiguration.java†L10-L18】
+3. 如果未提供独立模板，`RoadSafetyMapperFallbackConfiguration` 会让同一批 Mapper 回退到 Spring Boot 默认的主库模板，因此它们会落到 `xrcgs_admin` 数据库。 【F:xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperFallbackConfiguration.java†L10-L17】
+4. 主工程的 `@MapperScan` 范围排除了路产安全包，只覆盖 IAM、日志、文件、认证等模块，它们继续使用默认数据源。 【F:xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java†L10-L19】
+5. 多数据源的连接串、账号等配置在 `application-*.yml` 中按模块拆分：`spring.datasource.*` 对应主库，`spring.datasource.road-safety.*` 则供路产安全库使用。通过属性占位符 `${DB_ROAD_SAFETY_USER:${DB_USER:root}}` 等方式，支持按需覆盖或回退默认值。 【F:xrcgs-boot/src/main/resources/application-dev.yml†L1-L21】【F:xrcgs-boot/src/main/resources/application-prod.yml†L1-L21】
+
+### 让路产安全模块回退到主库 `xrcgs_admin`
+
+只要不在配置文件或外部参数中提供 `spring.datasource.road-safety.url`，`RoadSafetyDataSourceConfig` 就不会创建独立的连接池，`RoadSafetyMapperFallbackConfiguration` 便会生效。此时：
+
+1. 路产安全模块与其他模块一样共用默认数据源，所有读写均指向 `xrcgs_admin`。
+2. 不需要改动 Mapper 代码，因扫描配置会自动切换到默认模板。
+3. 如需重新启用独立库，只要恢复 `spring.datasource.road-safety.*` 配置即可。
+
+借助这种“按模块绑定模板”的方式，无需在代码中手动判断或切换，只要 Mapper 属于路产安全包，就会自动落到对应的数据源；其他模块则继续使用主库。
+
+## 外部配置的解析顺序
+
+Spring Boot 的配置属性支持从多个外部来源加载。`application-dev.yml` 和 `application-prod.yml` 中的数据源用户名写法为 `username: ${DB_USER:root}`，表示：
+
+1. **首先读取环境变量或 JVM 系统属性**：如果在运行应用时设置了 `DB_USER`（或 `DB_ROAD_SAFETY_USER`），Spring Boot 会直接使用这些变量的值。
+2. **可以通过启动参数覆盖**：例如使用 `java -jar app.jar --DB_USER=alice` 或者在 `mvn spring-boot:run -Dspring-boot.run.arguments="--DB_USER=alice"` 中传参。
+3. **也可以在外部配置文件中定义**：在同一目录放置 `application.yml`、`application-dev.yml` 等文件，或者创建 `application-local.yml` 并在启动时通过 `--spring.profiles.active=local` 指定。属性占位符会从激活的配置文件中解析。
+4. **若以上都未提供，则回退到冒号后的默认值**：示例中默认是 `root`。
+
+部署到 Linux / Docker 环境时，通常会在进程启动前导出环境变量，例如：
+
+```bash
+export DB_USER=prod_user
+export DB_PASSWORD=prod_password
+export DB_ROAD_SAFETY_USER=road_user
+export DB_ROAD_SAFETY_PASSWORD=road_password
+java -jar xrcgs-boot.jar --spring.profiles.active=prod
+```
+
+在 IDE 或本地开发环境下，也可以在运行配置中添加环境变量或通过 `application-dev.yml` 覆盖默认值。这些方式都是“外部配置”的来源。

--- a/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
+++ b/xrcgs-boot/src/main/java/com/xrcgs/boot/XrcgsAdminApplication.java
@@ -10,8 +10,10 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ConfigurationPropertiesScan(basePackages = "com.xrcgs") // 关键：让 @ConfigurationProperties 生效
 @MapperScan(
         basePackages = {
-                "com.xrcgs.*.mapper",   // 你原有 IAM 模块的 mapper
-                "com.xrcgs.auth.user"     // 新增 auth 模块里的 SysUserMapper 包
+                "com.xrcgs.iam.mapper",
+                "com.xrcgs.syslog.mapper",
+                "com.xrcgs.file.mapper",
+                "com.xrcgs.auth.user"
         },
         nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
 )

--- a/xrcgs-boot/src/main/resources/application-dev.yml
+++ b/xrcgs-boot/src/main/resources/application-dev.yml
@@ -8,6 +8,15 @@ spring:
       minimum-idle: 1
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+    road-safety:
+      url: jdbc:mysql://localhost:3306/xrcgs_roadSafety?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+      username: ${DB_ROAD_SAFETY_USER:${DB_USER:root}}
+      password: ${DB_ROAD_SAFETY_PASS:${DB_PASS:root}}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        maximum-pool-size: 5
+        minimum-idle: 1
+
   data:
     redis:
       host: localhost

--- a/xrcgs-boot/src/main/resources/application-prod.yml
+++ b/xrcgs-boot/src/main/resources/application-prod.yml
@@ -8,6 +8,15 @@ spring:
       minimum-idle: 1
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+    road-safety:
+      url: jdbc:mysql://localhost:3306/xrcgs_roadSafety?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+      username: ${DB_ROAD_SAFETY_USER:${DB_USER}}
+      password: ${DB_ROAD_SAFETY_PASS:${DB_PASS}}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        maximum-pool-size: 5
+        minimum-idle: 1
+
   data:
     redis:
       host: localhost

--- a/xrcgs-infrastructure/src/main/java/com/xrcgs/infrastructure/config/RoadSafetyDataSourceConfig.java
+++ b/xrcgs-infrastructure/src/main/java/com/xrcgs/infrastructure/config/RoadSafetyDataSourceConfig.java
@@ -1,0 +1,105 @@
+package com.xrcgs.infrastructure.config;
+
+import com.baomidou.mybatisplus.autoconfigure.MybatisPlusProperties;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+
+/**
+ * 数据源配置：为路产安全模块提供独立的数据源、会话工厂与事务管理。
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "spring.datasource.road-safety", name = "url")
+public class RoadSafetyDataSourceConfig {
+
+    private final MybatisPlusInterceptor mybatisPlusInterceptor;
+    private final MybatisPlusProperties mybatisPlusProperties;
+
+    public RoadSafetyDataSourceConfig(MybatisPlusInterceptor mybatisPlusInterceptor,
+                                      MybatisPlusProperties mybatisPlusProperties) {
+        this.mybatisPlusInterceptor = mybatisPlusInterceptor;
+        this.mybatisPlusProperties = mybatisPlusProperties;
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.road-safety")
+    public DataSourceProperties roadSafetyDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "roadSafetyDataSource")
+    @ConfigurationProperties("spring.datasource.road-safety.hikari")
+    public DataSource roadSafetyDataSource(@Qualifier("roadSafetyDataSourceProperties") DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    }
+
+    @Bean(name = "roadSafetySqlSessionFactory")
+    public SqlSessionFactory roadSafetySqlSessionFactory(@Qualifier("roadSafetyDataSource") DataSource dataSource) throws Exception {
+        var factory = new MybatisSqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        factory.setPlugins(mybatisPlusInterceptor);
+
+        var configuration = new MybatisConfiguration();
+        configuration.setMapUnderscoreToCamelCase(true);
+        factory.setConfiguration(configuration);
+
+        if (mybatisPlusProperties.getGlobalConfig() != null) {
+            factory.setGlobalConfig(mybatisPlusProperties.getGlobalConfig());
+        }
+
+        if (StringUtils.hasText(mybatisPlusProperties.getTypeAliasesPackage())) {
+            factory.setTypeAliasesPackage(mybatisPlusProperties.getTypeAliasesPackage());
+        }
+        if (StringUtils.hasText(mybatisPlusProperties.getTypeHandlersPackage())) {
+            factory.setTypeHandlersPackage(mybatisPlusProperties.getTypeHandlersPackage());
+        }
+
+        var mapperLocations = resolveMapperLocations("classpath*:mapper/roadsafety/**/*.xml");
+        if (mapperLocations.length > 0) {
+            factory.setMapperLocations(mapperLocations);
+        }
+
+        return factory.getObject();
+    }
+
+    @Bean(name = "roadSafetySqlSessionTemplate")
+    public SqlSessionTemplate roadSafetySqlSessionTemplate(@Qualifier("roadSafetySqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+
+    @Bean(name = "roadSafetyTransactionManager")
+    public DataSourceTransactionManager roadSafetyTransactionManager(@Qualifier("roadSafetyDataSource") DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    private Resource[] resolveMapperLocations(String... mapperLocations) throws IOException {
+        List<Resource> resources = new ArrayList<>();
+        var resolver = new PathMatchingResourcePatternResolver();
+        for (String mapperLocation : mapperLocations) {
+            if (!StringUtils.hasText(mapperLocation)) {
+                continue;
+            }
+            resources.addAll(List.of(resolver.getResources(mapperLocation)));
+        }
+        return resources.toArray(new Resource[0]);
+    }
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperConfiguration.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperConfiguration.java
@@ -1,0 +1,19 @@
+package com.xrcgs.roadsafety.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+/**
+ * 在独立路产安全数据源启用时，将 Mapper 绑定到专属 SqlSessionTemplate。
+ */
+@Configuration
+@ConditionalOnBean(name = "roadSafetySqlSessionTemplate")
+@MapperScan(
+        basePackages = "com.xrcgs.roadsafety.**.mapper",
+        sqlSessionTemplateRef = "roadSafetySqlSessionTemplate",
+        nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
+)
+public class RoadSafetyMapperConfiguration {
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperFallbackConfiguration.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/config/RoadSafetyMapperFallbackConfiguration.java
@@ -1,0 +1,18 @@
+package com.xrcgs.roadsafety.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+/**
+ * 当未显式配置路产安全独立数据源时，让模块回退到主库的 SqlSessionTemplate。
+ */
+@Configuration
+@ConditionalOnMissingBean(name = "roadSafetySqlSessionTemplate")
+@MapperScan(
+        basePackages = "com.xrcgs.roadsafety.**.mapper",
+        nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
+)
+public class RoadSafetyMapperFallbackConfiguration {
+}


### PR DESCRIPTION
## Summary
- split the road safety mapper scan into conditional configurations so it uses the dedicated datasource only when available
- document how the module automatically falls back to the primary xrcgs_admin datasource when the road safety pool is not configured

## Testing
- mvn -pl xrcgs-module-road-safety -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e34dce77608321b5529a0018af2e6d