### PR TITLE
feat(road-safety): persist inspection log exports to storage

### DIFF
--- a/xrcgs-boot/src/main/resources/application-dev.yml
+++ b/xrcgs-boot/src/main/resources/application-dev.yml
@@ -56,3 +56,6 @@ convert:
 # LibreOffice 安装路径（如放空则按系统默认）
 libreoffice:
   home: ""    # Linux: /opt/libreoffice7.6 ；Windows: C:\Program Files\LibreOffice\program\soffice.exe 的上级目录
+
+road-safety:
+  inspection-log: data/inspection-logs  # 巡查日志Excel持久化目录

--- a/xrcgs-boot/src/main/resources/application-prod.yml
+++ b/xrcgs-boot/src/main/resources/application-prod.yml
@@ -38,3 +38,6 @@ syslog:
 logging:
   level:
     com.xrcgs.syslog.mapper: error
+
+road-safety:
+  inspection-log: data/inspection-logs

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionLogApplicationService.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionLogApplicationService.java
@@ -1,0 +1,469 @@
+package com.xrcgs.roadsafety.inspection.application.service;
+
+import com.xrcgs.roadsafety.inspection.config.InspectionLogProperties;
+import com.xrcgs.roadsafety.inspection.domain.model.HandlingCategoryGroup;
+import com.xrcgs.roadsafety.inspection.domain.model.InspectionRecord;
+import com.xrcgs.roadsafety.inspection.domain.model.PhotoItem;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.ContactDelivery;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.DetailType;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.HandoverInfo;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.InspectionDetail;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.Mileage;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest.MileageInfo;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * 巡查日志应用服务：负责将前端提交的数据结构转换为领域实体，并驱动 Excel 导出流程。
+ */
+@Service
+@RequiredArgsConstructor
+public class InspectionLogApplicationService {
+
+    private static final DateTimeFormatter ISO_DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    private final InspectionRecordExcelExporter excelExporter;
+    private final InspectionLogProperties logProperties;
+
+    /**
+     * 根据巡查日志请求生成 Excel 文件。
+     *
+     * @param request 前端提交的巡查日志数据
+     * @return 生成 Excel 文件的路径
+     */
+    public Path generateInspectionLog(InspectionLogSubmitRequest request) throws IOException {
+        InspectionRecord record = buildInspectionRecord(request);
+        Path storageDirectory = resolveStorageDirectory();
+        Path exported = excelExporter.export(record, storageDirectory);
+        // 保障导出文件存在且可读，否则抛出异常给调用方感知。
+        if (!Files.exists(exported)) {
+            throw new IOException("巡查日志导出失败，未生成文件");
+        }
+        return exported;
+    }
+
+    private Path resolveStorageDirectory() throws IOException {
+        String configuredDirectory = Optional.ofNullable(logProperties.getInspectionLog())
+                .map(String::trim)
+                .orElse("");
+        if (!StringUtils.hasText(configuredDirectory)) {
+            throw new IllegalStateException("巡查日志存储目录未配置，请在 road-safety.inspection-log 中指定");
+        }
+        try {
+            Path storagePath = Paths.get(configuredDirectory).toAbsolutePath().normalize();
+            Files.createDirectories(storagePath);
+            return storagePath;
+        } catch (InvalidPathException ex) {
+            throw new IOException("巡查日志存储目录配置非法：" + configuredDirectory, ex);
+        }
+    }
+
+    private InspectionRecord buildInspectionRecord(InspectionLogSubmitRequest request) {
+        LocalDate inspectionDate = parseDate(request.getDate());
+        String shiftText = translateShift(request.getShiftType());
+        String routeText = joinWithDelimiter("、", request.getRoutes());
+        String mileageText = buildMileageText(request.getMileage());
+        String location = joinNonBlank("；", routeText, mileageText);
+        List<InspectionDetail> detailList = Optional.ofNullable(request.getDetails()).orElseGet(Collections::emptyList);
+        HandlingCategoryGroup categoryGroup = buildHandlingGroup(detailList);
+        String issuesFound = buildIssuesFound(detailList);
+        String handlingRaw = buildHandlingSituationRaw(detailList);
+        String inspectionContent = buildInspectionContent(request, shiftText, routeText, mileageText, detailList.size());
+        String remark = buildRemark(request);
+        String handoverSummary = buildHandoverSummary(request.getHandover());
+        List<PhotoItem> photos = buildPhotos(detailList);
+        LocalDateTime now = LocalDateTime.now();
+        String inspectorNames = joinWithDelimiter("、", Optional.ofNullable(request.getHandover())
+                .map(HandoverInfo::getInspectors)
+                .orElse(Collections.emptyList()));
+
+        return InspectionRecord.builder()
+                .date(inspectionDate)
+                .unitName(StringUtils.trimWhitespace(request.getUnitName()))
+                .weather(StringUtils.trimWhitespace(request.getWeather()))
+                .patrolTeam(inspectorNames)
+                .patrolVehicle(StringUtils.trimWhitespace(request.getVehicle()))
+                .location(location)
+                .inspectionContent(inspectionContent)
+                .issuesFound(issuesFound)
+                .handlingSituationRaw(handlingRaw)
+                .handlingDetails(categoryGroup)
+                .handoverSummary(handoverSummary)
+                .photos(photos)
+                .remark(remark)
+                .createdBy(inspectorNames)
+                .createdAt(now)
+                .updatedAt(now)
+                .exportedBy(inspectorNames)
+                .exportedAt(now)
+                .exportFileName(determineExportFileName(request, inspectionDate))
+                .build();
+    }
+
+    private LocalDate parseDate(String dateText) {
+        try {
+            return LocalDate.parse(dateText, ISO_DATE);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("巡查日期格式错误，应为 YYYY-MM-DD", ex);
+        }
+    }
+
+    private String translateShift(InspectionLogSubmitRequest.ShiftType shiftType) {
+        return switch (shiftType) {
+            case DAY -> "白班";
+            case NIGHT -> "夜班";
+            case BOTH -> "白班+夜班";
+        };
+    }
+
+    private String buildMileageText(Mileage mileage) {
+        if (mileage == null) {
+            return null;
+        }
+        List<String> segments = new ArrayList<>();
+        if (mileage.getDay() != null) {
+            String dayText = normalizeMileageDisplay(mileage.getDay());
+            if (StringUtils.hasText(dayText)) {
+                segments.add("白班：" + dayText);
+            }
+        }
+        if (mileage.getNight() != null) {
+            String nightText = normalizeMileageDisplay(mileage.getNight());
+            if (StringUtils.hasText(nightText)) {
+                segments.add("夜班：" + nightText);
+            }
+        }
+        return segments.isEmpty() ? null : String.join("；", segments);
+    }
+
+    private String normalizeMileageDisplay(MileageInfo info) {
+        if (info == null) {
+            return "";
+        }
+        if (StringUtils.hasText(info.getDisplayText())) {
+            return info.getDisplayText().trim();
+        }
+        List<String> segments = new ArrayList<>();
+        if (StringUtils.hasText(info.getStartStake()) && StringUtils.hasText(info.getEndStake())) {
+            segments.add(info.getStartStake().trim() + "-" + info.getEndStake().trim());
+        }
+        if (info.getTotalKm() != null) {
+            segments.add(String.format("总计%.3fKM", info.getTotalKm()));
+        }
+        return segments.isEmpty() ? "" : String.join("（", segments) + (segments.size() > 1 ? "）" : "");
+    }
+
+    private HandlingCategoryGroup buildHandlingGroup(List<InspectionDetail> details) {
+        Map<DetailType, List<String>> bucket = new EnumMap<>(DetailType.class);
+        for (DetailType type : DetailType.values()) {
+            bucket.put(type, new ArrayList<>());
+        }
+        for (InspectionDetail detail : details) {
+            if (detail == null || detail.getType() == null) {
+                continue;
+            }
+            String summary = buildDetailSummary(detail);
+            bucket.get(detail.getType()).add(summary);
+        }
+        return HandlingCategoryGroup.builder()
+                .roadDamage(bucket.get(DetailType.ROAD_DAMAGE))
+                .trafficAccidents(bucket.get(DetailType.ACCIDENT))
+                .roadRescue(bucket.get(DetailType.RESCUE))
+                .facilityCompensations(bucket.get(DetailType.COMPENSATION))
+                .largeVehicleChecks(bucket.get(DetailType.OVERSIZE))
+                .overloadVehicleHandling(bucket.get(DetailType.OVERLOAD))
+                .constructionChecks(bucket.get(DetailType.CONSTRUCTION))
+                .illegalInfringements(bucket.get(DetailType.VIOLATION))
+                .otherMatters(bucket.get(DetailType.OTHER))
+                .build();
+    }
+
+    private String buildIssuesFound(List<InspectionDetail> details) {
+        List<String> lines = details.stream()
+                .filter(Objects::nonNull)
+                .map(this::formatIssueLine)
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .toList();
+        return joinLines(lines);
+    }
+
+    private String formatIssueLine(InspectionDetail detail) {
+        List<String> parts = new ArrayList<>();
+        if (StringUtils.hasText(detail.getTime())) {
+            parts.add(detail.getTime().trim());
+        }
+        if (StringUtils.hasText(detail.getLocation())) {
+            parts.add(detail.getLocation().trim());
+        }
+        if (StringUtils.hasText(detail.getDescription())) {
+            parts.add(detail.getDescription().trim());
+        }
+        return parts.isEmpty() ? null : parts.stream().collect(Collectors.joining("：", "", ""));
+    }
+
+    private String buildHandlingSituationRaw(List<InspectionDetail> details) {
+        List<String> lines = details.stream()
+                .filter(Objects::nonNull)
+                .map(detail -> {
+                    if (!StringUtils.hasText(detail.getResult())) {
+                        return null;
+                    }
+                    List<String> parts = new ArrayList<>();
+                    if (StringUtils.hasText(detail.getTime())) {
+                        parts.add(detail.getTime().trim());
+                    }
+                    if (StringUtils.hasText(detail.getLocation())) {
+                        parts.add(detail.getLocation().trim());
+                    }
+                    parts.add("处理结果：" + detail.getResult().trim());
+                    return String.join("，", parts);
+                })
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .toList();
+        return joinLines(lines);
+    }
+
+    private String buildInspectionContent(InspectionLogSubmitRequest request, String shiftText,
+                                          String routeText, String mileageText, int detailCount) {
+        List<String> segments = new ArrayList<>();
+        segments.add("班次：" + shiftText);
+        if (StringUtils.hasText(routeText)) {
+            segments.add("巡查路线：" + routeText);
+        }
+        if (StringUtils.hasText(mileageText)) {
+            segments.add("巡查里程：" + mileageText);
+        }
+        segments.add("天气：" + defaultText(request.getWeather()));
+        segments.add("巡查事件：" + detailCount + " 项");
+        return String.join("；", segments);
+    }
+
+    private String buildRemark(InspectionLogSubmitRequest request) {
+        List<String> remarkLines = new ArrayList<>();
+        if (StringUtils.hasText(request.getRemark())) {
+            remarkLines.add(request.getRemark().trim());
+        }
+        Optional.ofNullable(request.getHandover())
+                .map(HandoverInfo::getRemark)
+                .filter(StringUtils::hasText)
+                .ifPresent(value -> remarkLines.add("交接备注：" + value.trim()));
+        if (!CollectionUtils.isEmpty(request.getDeliveries())) {
+            String deliveries = request.getDeliveries().stream()
+                    .filter(Objects::nonNull)
+                    .map(this::formatDelivery)
+                    .filter(StringUtils::hasText)
+                    .collect(Collectors.joining("；"));
+            if (StringUtils.hasText(deliveries)) {
+                remarkLines.add("送达联系单：" + deliveries);
+            }
+        }
+        if (Boolean.TRUE.equals(request.getDraft())) {
+            remarkLines.add("当前记录为草稿，尚未正式提交审批。");
+        }
+        return joinLines(remarkLines);
+    }
+
+    private String formatDelivery(ContactDelivery delivery) {
+        List<String> parts = new ArrayList<>();
+        if (delivery == null) {
+            return null;
+        }
+        if (StringUtils.hasText(delivery.getUnit())) {
+            parts.add(delivery.getUnit().trim());
+        }
+        if (StringUtils.hasText(delivery.getNumber())) {
+            parts.add("编号：" + delivery.getNumber().trim());
+        }
+        if (StringUtils.hasText(delivery.getDate())) {
+            parts.add("日期：" + delivery.getDate().trim());
+        }
+        if (StringUtils.hasText(delivery.getRemark())) {
+            parts.add(delivery.getRemark().trim());
+        }
+        return parts.isEmpty() ? null : String.join("，", parts);
+    }
+
+    private String buildHandoverSummary(HandoverInfo handover) {
+        if (handover == null) {
+            return null;
+        }
+        List<String> parts = new ArrayList<>();
+        if (StringUtils.hasText(handover.getNote())) {
+            parts.add(handover.getNote().trim());
+        }
+        if (!CollectionUtils.isEmpty(handover.getInspectors())) {
+            parts.add("巡查人员：" + joinWithDelimiter("、", handover.getInspectors()));
+        }
+        if (!CollectionUtils.isEmpty(handover.getHandoverFrom())) {
+            parts.add("交班人员：" + joinWithDelimiter("、", handover.getHandoverFrom()));
+        }
+        if (!CollectionUtils.isEmpty(handover.getHandoverTo())) {
+            parts.add("接班人员：" + joinWithDelimiter("、", handover.getHandoverTo()));
+        }
+        if (StringUtils.hasText(handover.getRemark())) {
+            parts.add("备注：" + handover.getRemark().trim());
+        }
+        return joinNonBlank("；", parts.toArray(new String[0]));
+    }
+
+    private List<PhotoItem> buildPhotos(List<InspectionDetail> details) {
+        List<PhotoItem> photos = new ArrayList<>();
+        AtomicInteger order = new AtomicInteger(1);
+        for (InspectionDetail detail : details) {
+            if (detail == null || CollectionUtils.isEmpty(detail.getPhotos())) {
+                continue;
+            }
+            for (InspectionLogSubmitRequest.PhotoItem photoItem : detail.getPhotos()) {
+                if (photoItem == null || !StringUtils.hasText(photoItem.getUrl())) {
+                    continue;
+                }
+                String description = StringUtils.hasText(photoItem.getCaption())
+                        ? photoItem.getCaption().trim()
+                        : Optional.ofNullable(detail.getSummaryText())
+                                .filter(StringUtils::hasText)
+                                .map(String::trim)
+                                .orElseGet(() -> defaultText(detail.getDescription()));
+                photos.add(PhotoItem.builder()
+                        .imagePath(photoItem.getUrl().trim())
+                        .description(description)
+                        .sortOrder(order.getAndIncrement())
+                        .build());
+            }
+        }
+        return photos;
+    }
+
+    private String buildDetailSummary(InspectionDetail detail) {
+        if (detail == null) {
+            return "";
+        }
+        if (StringUtils.hasText(detail.getSummaryText())) {
+            return detail.getSummaryText().trim();
+        }
+        List<String> segments = new ArrayList<>();
+        if (StringUtils.hasText(detail.getTime())) {
+            segments.add(detail.getTime().trim());
+        }
+        if (StringUtils.hasText(detail.getLocation())) {
+            segments.add(detail.getLocation().trim());
+        }
+        if (StringUtils.hasText(detail.getDescription())) {
+            segments.add(detail.getDescription().trim());
+        }
+        if (StringUtils.hasText(detail.getResult())) {
+            segments.add("处置：" + detail.getResult().trim());
+        }
+        if (StringUtils.hasText(detail.getCompany())) {
+            segments.add("施工单位：" + detail.getCompany().trim());
+        }
+        if (StringUtils.hasText(detail.getWorkContent())) {
+            segments.add("作业内容：" + detail.getWorkContent().trim());
+        }
+        if (StringUtils.hasText(detail.getSiteCondition())) {
+            segments.add("现场情况：" + detail.getSiteCondition().trim());
+        }
+        if (StringUtils.hasText(detail.getSafetyMeasure())) {
+            segments.add("安全措施：" + detail.getSafetyMeasure().trim());
+        }
+        if (detail.getAmount() != null) {
+            segments.add("金额：" + detail.getAmount());
+        }
+        if (StringUtils.hasText(detail.getPricingBasis())) {
+            segments.add("计价依据：" + detail.getPricingBasis().trim());
+        }
+        if (StringUtils.hasText(detail.getPlateNo())) {
+            segments.add("车牌：" + detail.getPlateNo().trim());
+        }
+        if (StringUtils.hasText(detail.getFaultReason())) {
+            segments.add("原因：" + detail.getFaultReason().trim());
+        }
+        if (StringUtils.hasText(detail.getEvacuateAt())) {
+            segments.add("离场时间：" + detail.getEvacuateAt().trim());
+        }
+        return segments.isEmpty() ? defaultText(detail.getDescription()) : String.join("，", segments);
+    }
+
+    private String joinWithDelimiter(String delimiter, List<String> values) {
+        if (CollectionUtils.isEmpty(values)) {
+            return null;
+        }
+        String joined = values.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .collect(Collectors.joining(delimiter));
+        return StringUtils.hasText(joined) ? joined : null;
+    }
+
+    private String joinNonBlank(String delimiter, String... values) {
+        String joined = Stream.of(values)
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .collect(Collectors.joining(delimiter));
+        return StringUtils.hasText(joined) ? joined : null;
+    }
+
+    private String defaultText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : "无";
+    }
+
+    private String joinLines(List<String> lines) {
+        if (CollectionUtils.isEmpty(lines)) {
+            return null;
+        }
+        return lines.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private String determineExportFileName(InspectionLogSubmitRequest request, LocalDate date) {
+        if (StringUtils.hasText(request.getFileName())) {
+            return ensureExcelExtension(sanitizeFileName(request.getFileName().trim()));
+        }
+        String unitName = request.getUnitName();
+        if (StringUtils.hasText(unitName)) {
+            return ensureExcelExtension(sanitizeFileName(unitName.trim()) + "巡查日志");
+        }
+        String datePart = date != null ? date.format(DateTimeFormatter.BASIC_ISO_DATE) : "inspection";
+        return "inspection_log_" + datePart + ".xlsx";
+    }
+
+    private String ensureExcelExtension(String fileName) {
+        String normalized = fileName.toLowerCase();
+        if (normalized.endsWith(".xlsx")) {
+            return fileName;
+        }
+        if (normalized.endsWith(".xls")) {
+            return fileName.substring(0, fileName.length() - 4) + ".xlsx";
+        }
+        return fileName + ".xlsx";
+    }
+
+    private String sanitizeFileName(String value) {
+        return value.replaceAll("[\\\\/:*?\"<>|]", "_");
+    }
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/config/InspectionLogProperties.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/config/InspectionLogProperties.java
@@ -1,0 +1,21 @@
+package com.xrcgs.roadsafety.inspection.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 巡查日志相关配置项。
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "road-safety")
+public class InspectionLogProperties {
+
+    /**
+     * 巡查日志 Excel 文件在磁盘上的持久化目录（绝对路径或相对项目根路径）。
+     */
+    private String inspectionLog;
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/interfaces/controller/InspectionLogController.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/interfaces/controller/InspectionLogController.java
@@ -1,0 +1,62 @@
+package com.xrcgs.roadsafety.inspection.interfaces.controller;
+
+import com.xrcgs.roadsafety.inspection.application.service.InspectionLogApplicationService;
+import com.xrcgs.roadsafety.inspection.interfaces.dto.InspectionLogSubmitRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 巡查日志导出接口，接收前端提交的巡查数据并返回生成的 Excel 文件。
+ */
+@RestController
+@RequestMapping("/api/road-safety/inspection/logs")
+@RequiredArgsConstructor
+@Validated
+public class InspectionLogController {
+
+    private static final Logger log = LoggerFactory.getLogger(InspectionLogController.class);
+
+    private final InspectionLogApplicationService applicationService;
+
+    /**
+     * 生成巡查日志 Excel 文件并以附件形式返回。
+     *
+     * @param request  巡查日志提交数据
+     * @param response HTTP 响应对象
+     */
+    @PostMapping("/export")
+    public void export(@Valid @RequestBody InspectionLogSubmitRequest request,
+                       HttpServletResponse response) throws IOException {
+        Path exportFile = applicationService.generateInspectionLog(request);
+        try (InputStream inputStream = Files.newInputStream(exportFile)) {
+            String fileName = exportFile.getFileName().toString();
+            String encodedName = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + encodedName
+                    + "\"; filename*=utf-8''" + encodedName);
+            response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+            response.setHeader("Pragma", "no-cache");
+            response.setHeader("Expires", "0");
+            inputStream.transferTo(response.getOutputStream());
+            response.flushBuffer();
+        } catch (IOException ex) {
+            log.error("巡查日志导出失败", ex);
+            throw ex;
+        }
+    }
+}

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/interfaces/dto/InspectionLogSubmitRequest.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/interfaces/dto/InspectionLogSubmitRequest.java
@@ -1,0 +1,292 @@
+package com.xrcgs.roadsafety.inspection.interfaces.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * 巡查日志提交入参，请求结构贴合前端模型，便于后续扩展。
+ */
+@Data
+public class InspectionLogSubmitRequest {
+
+    /**
+     * 巡查日期（格式：YYYY-MM-DD）。
+     */
+    @NotBlank(message = "巡查日期不能为空")
+    private String date;
+
+    /**
+     * 班次类型：DAY=白班，NIGHT=夜班，BOTH=两班都有。
+     */
+    @NotNull(message = "班次类型不能为空")
+    private ShiftType shiftType;
+
+    /**
+     * 巡查路段ID数组（例如：["R001","R002"]）。
+     */
+    @NotEmpty(message = "巡查路段不能为空")
+    private List<@NotBlank String> routes;
+
+    /**
+     * 巡查车辆编号（或车牌号）。
+     */
+    @NotBlank(message = "巡查车辆不能为空")
+    private String vehicle;
+
+    /**
+     * 天气描述（如：晴 / 阴 / 雨 / 雪 / 风沙 / 其他）。
+     */
+    @NotBlank(message = "天气情况不能为空")
+    private String weather;
+
+    /**
+     * 里程信息，区分白班与夜班。
+     */
+    @Valid
+    private Mileage mileage;
+
+    /**
+     * 备注信息（可选）。
+     */
+    private String remark;
+
+    /**
+     * 巡查、处理情况记录明细。
+     */
+    @NotEmpty(message = "巡查明细不能为空")
+    private List<@Valid InspectionDetail> details;
+
+    /**
+     * 人员与交接信息。
+     */
+    @Valid
+    @NotNull(message = "交接信息不能为空")
+    private HandoverInfo handover;
+
+    /**
+     * 送达联系单信息（可选，多条）。
+     */
+    @Valid
+    private List<ContactDelivery> deliveries;
+
+    /**
+     * 客户端保存草稿标志（true=仅保存草稿，false=正式提交）。
+     */
+    private Boolean draft;
+
+    /**
+     * 导出文件名称（可选，后缀自动补齐为 .xlsx）。
+     */
+    @Size(max = 128, message = "导出文件名长度不能超过128个字符")
+    private String fileName;
+
+    /**
+     * 单位名称，用于表头展示。
+     */
+    @Size(max = 128, message = "单位名称长度不能超过128个字符")
+    private String unitName;
+
+    /**
+     * 班次类型枚举。
+     */
+    public enum ShiftType {
+        /** 白班。 */
+        DAY,
+        /** 夜班。 */
+        NIGHT,
+        /** 白班+夜班。 */
+        BOTH
+    }
+
+    /**
+     * 里程信息对象。
+     */
+    @Data
+    public static class Mileage {
+
+        /**
+         * 白班里程（可为空）。
+         */
+        @Valid
+        private MileageInfo day;
+
+        /**
+         * 夜班里程（可为空）。
+         */
+        @Valid
+        private MileageInfo night;
+    }
+
+    /**
+     * 单段里程信息。
+     */
+    @Data
+    public static class MileageInfo {
+
+        /** 起点桩号（格式示例："K0+000"）。 */
+        @NotBlank(message = "里程起点不能为空")
+        private String startStake;
+
+        /** 终点桩号（格式示例："K45+000"）。 */
+        @NotBlank(message = "里程终点不能为空")
+        private String endStake;
+
+        /** 总里程（单位：千米，保留3位小数）。 */
+        @NotNull(message = "总里程不能为空")
+        private Double totalKm;
+
+        /** 展示用规范文本（例如："K0+000–K45+000（总计45.000KM）"）。 */
+        @NotBlank(message = "里程展示文本不能为空")
+        private String displayText;
+    }
+
+    /**
+     * 巡查/处理情况条目。
+     */
+    @Data
+    public static class InspectionDetail {
+
+        /** 类型（ROAD_DAMAGE、ACCIDENT、RESCUE、COMPENSATION、OVERSIZE、OVERLOAD、CONSTRUCTION、VIOLATION、OTHER）。 */
+        @NotNull(message = "明细类型不能为空")
+        private DetailType type;
+
+        /** 发生时间（格式：HH:mm）。 */
+        private String time;
+
+        /** 位置（如："上行K45+600"）。 */
+        private String location;
+
+        /** 现象或事件描述。 */
+        @NotBlank(message = "事件描述不能为空")
+        private String description;
+
+        /** 处理结果或采取措施（文本，可为空）。 */
+        private String result;
+
+        /** 施工单位名称（仅施工类使用）。 */
+        private String company;
+
+        /** 作业内容（施工类使用）。 */
+        private String workContent;
+
+        /** 现场情况（施工类使用）。 */
+        private String siteCondition;
+
+        /** 安全措施（施工类使用）。 */
+        private String safetyMeasure;
+
+        /** 金额或赔偿测算（仅赔补偿类使用）。 */
+        private Double amount;
+
+        /** 计价依据或标准说明（赔补偿类使用）。 */
+        private String pricingBasis;
+
+        /** 车牌号（用于事故、清障、大件、超限）。 */
+        private String plateNo;
+
+        /** 故障原因或事故原因（用于清障救援）。 */
+        private String faultReason;
+
+        /** 拖离/驶离时间（用于事故、救援）。 */
+        private String evacuateAt;
+
+        /** 照片列表（照片与描述一一对应）。 */
+        @Valid
+        private List<PhotoItem> photos;
+
+        /** 系统自动生成的汇总句子（用户可修改）。 */
+        private String summaryText;
+    }
+
+    /**
+     * 巡查照片信息。
+     */
+    @Data
+    public static class PhotoItem {
+
+        /** 照片访问URL或Base64数据。 */
+        @NotBlank(message = "照片URL不能为空")
+        private String url;
+
+        /** 照片描述。 */
+        private String caption;
+
+        /** 上传时间（可选）。 */
+        private String uploadedAt;
+    }
+
+    /**
+     * 人员与交接信息。
+     */
+    @Data
+    public static class HandoverInfo {
+
+        /** 巡查人员ID数组（或姓名数组）。 */
+        @NotEmpty(message = "巡查人员不能为空")
+        private List<@NotBlank String> inspectors;
+
+        /** 交班人ID数组。 */
+        private List<@NotBlank String> handoverFrom;
+
+        /** 接班人ID数组。 */
+        private List<@NotBlank String> handoverTo;
+
+        /** 车辆、案件等交接情况说明。 */
+        @NotBlank(message = "交接说明不能为空")
+        private String note;
+
+        /** 其他备注（选填）。 */
+        private String remark;
+    }
+
+    /**
+     * 送达联系单信息。
+     */
+    @Data
+    public static class ContactDelivery {
+
+        /** 送达单位名称。 */
+        @NotBlank(message = "送达单位不能为空")
+        private String unit;
+
+        /** 联系单编号。 */
+        @NotBlank(message = "联系单编号不能为空")
+        private String number;
+
+        /** 送达日期（格式：YYYY-MM-DD）。 */
+        @NotBlank(message = "送达日期不能为空")
+        private String date;
+
+        /** 备注说明。 */
+        private String remark;
+    }
+
+    /**
+     * 明细类型枚举，与前端约定的类型保持一致。
+     */
+    public enum DetailType {
+        /** 道路病害或损坏情况。 */
+        ROAD_DAMAGE,
+        /** 交通事故。 */
+        ACCIDENT,
+        /** 清障救援。 */
+        RESCUE,
+        /** 设施赔补偿情况。 */
+        COMPENSATION,
+        /** 大件检查。 */
+        OVERSIZE,
+        /** 超限处理。 */
+        OVERLOAD,
+        /** 涉路施工检查。 */
+        CONSTRUCTION,
+        /** 违法侵权事件。 */
+        VIOLATION,
+        /** 其他情况。 */
+        OTHER
+    }
+}


### PR DESCRIPTION
## Summary
- persist patrol log Excel exports into the configured storage directory and default the filename to "所属中队巡查日志"
- bind the `road-safety.inspection-log` property via `InspectionLogProperties` and ensure the destination directory exists before writing
- keep the generated workbook on disk for reuse and add the storage path to both dev/prod application YAML files

## Testing
- mvn -pl xrcgs-module-road-safety -am test

------
https://chatgpt.com/codex/tasks/task_e_68e3ca0483788321a8336766b209e914