### PR TITLE
Include road safety module in boot build

### DIFF
--- a/xrcgs-boot/pom.xml
+++ b/xrcgs-boot/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>xrcgs-module-file</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.xrcgs</groupId>
+            <artifactId>xrcgs-module-road-safety</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- add the road safety module dependency to the boot application so its controllers are registered

## Testing
- mvn -pl xrcgs-boot -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e53d05a38c8321b6aa72ff90f9b8c0