### PR TITLE
feat: load inspection log template from configuration

### DIFF
--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/application/service/InspectionRecordExcelExporter.java
@@ -1,5 +1,6 @@
 package com.xrcgs.roadsafety.inspection.application.service;
 
+import com.xrcgs.roadsafety.inspection.config.InspectionLogProperties;
 import com.xrcgs.roadsafety.inspection.domain.model.HandlingCategoryGroup;
 import com.xrcgs.roadsafety.inspection.domain.model.InspectionRecord;
 import com.xrcgs.roadsafety.inspection.domain.model.PhotoItem;
@@ -9,9 +10,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.InvalidPathException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -41,6 +42,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -71,14 +73,20 @@ public class InspectionRecordExcelExporter {
     );
 
     // 注入模板资源，便于在不同运行环境或测试中覆盖默认模板。
-    private final Resource templateResource;
+    private final Resource templateResourceOverride;
+    private final InspectionLogProperties logProperties;
 
-    public InspectionRecordExcelExporter() {
-        this(new ClassPathResource(TEMPLATE_CLASSPATH));
+    public InspectionRecordExcelExporter(InspectionLogProperties logProperties) {
+        this(logProperties, null);
     }
 
     InspectionRecordExcelExporter(Resource templateResource) {
-        this.templateResource = templateResource;
+        this(null, templateResource);
+    }
+
+    private InspectionRecordExcelExporter(InspectionLogProperties logProperties, Resource templateResourceOverride) {
+        this.logProperties = logProperties;
+        this.templateResourceOverride = templateResourceOverride;
     }
 
     /**
@@ -123,10 +131,34 @@ public class InspectionRecordExcelExporter {
     }
 
     private InputStream openTemplate() throws IOException {
-        if (!templateResource.exists()) {
-            throw new IOException("巡查记录模板不存在: " + templateResource.getDescription());
+        Resource resource = resolveTemplateResource();
+        if (!resource.exists()) {
+            throw new IOException("巡查记录模板不存在: " + resource.getDescription());
         }
-        return templateResource.getInputStream();
+        return resource.getInputStream();
+    }
+
+    private Resource resolveTemplateResource() throws IOException {
+        if (templateResourceOverride != null) {
+            return templateResourceOverride;
+        }
+        String configuredTemplate = Optional.ofNullable(logProperties)
+                .map(InspectionLogProperties::getLogTemplate)
+                .map(String::trim)
+                .orElse("");
+        if (StringUtils.hasText(configuredTemplate)) {
+            try {
+                Path templatePath = Paths.get(configuredTemplate).toAbsolutePath().normalize();
+                Resource fileResource = new FileSystemResource(templatePath);
+                if (!fileResource.exists()) {
+                    throw new IOException("巡查记录模板不存在: " + templatePath);
+                }
+                return fileResource;
+            } catch (InvalidPathException ex) {
+                throw new IOException("巡查记录模板路径非法: " + configuredTemplate, ex);
+            }
+        }
+        return new ClassPathResource(TEMPLATE_CLASSPATH);
     }
 
     private void fillHeaderInfo(XSSFSheet sheet, InspectionRecord record) {

--- a/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/config/InspectionLogProperties.java
+++ b/xrcgs-module-road-safety/src/main/java/com/xrcgs/roadsafety/inspection/config/InspectionLogProperties.java
@@ -18,4 +18,9 @@ public class InspectionLogProperties {
      * 巡查日志 Excel 文件在磁盘上的持久化目录（绝对路径或相对项目根路径）。
      */
     private String inspectionLog;
+
+    /**
+     * 巡查日志 Excel 模板文件路径（绝对路径或相对项目根路径）。
+     */
+    private String logTemplate;
 }


### PR DESCRIPTION
## Summary
- read the inspection log Excel template path from the `road-safety.log-template` configuration
- resolve the configured template file from the filesystem with validation and fall back to the bundled classpath template
- expose the new template path property on `InspectionLogProperties`

## Testing
- mvn -pl xrcgs-module-road-safety test -Dtest=InspectionRecordExcelExporterTest *(fails: missing internal module artifacts in the local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e8b54f2c832196d4383f3750badd