### PR TITLE
增强巡查日志导出对文件预览地址的支持

### DIFF
--- a/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/SecurityConfig.java
+++ b/xrcgs-module-auth/src/main/java/com/xrcgs/auth/security/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**", "/api/ping", "/actuator/**").permitAll()
+                        // 文件模块的预览、下载接口需给巡查日志导出场景匿名访问，以便 Excel 写入时读取图片
+                        .requestMatchers("/api/file/preview/**", "/api/file/download/**").permitAll()
 //                        .requestMatchers("/api/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- 放开文件模块预览与下载接口的匿名访问权限，避免无 token 时返回 401
- 巡查日志应用服务从照片 URL 中解析文件 ID 并写入领域对象
- Excel 导出器注入文件服务/存储能力，支持通过文件 ID 读取图片写入模板，兼容缺省路径

## Testing
- mvn -pl xrcgs-module-road-safety test *(fails: 无法解析内部模块依赖，需在父工程先安装相关模块)*

------
https://chatgpt.com/codex/tasks/task_e_68e645d23cd8832182e958bbe0ce4ae3